### PR TITLE
feature/auth api

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -9,6 +9,12 @@ dependencies {
 
 	/* spring app */
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	implementation group: 'org.springframework', name: 'spring-tx', version: '6.1.1'
+
+	/* redis */
+	implementation("org.springframework.session:spring-session-data-redis")
+	implementation 'io.lettuce:lettuce-core:6.2.3.RELEASE'
 }
 
 tasks.named('test') {

--- a/application/src/main/java/team/themoment/officialgsm/common/annotation/UseCase.java
+++ b/application/src/main/java/team/themoment/officialgsm/common/annotation/UseCase.java
@@ -1,0 +1,8 @@
+package team.themoment.officialgsm.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+public @interface UseCase {
+}

--- a/application/src/main/java/team/themoment/officialgsm/common/annotation/UseCaseWithReadOnlyTransaction.java
+++ b/application/src/main/java/team/themoment/officialgsm/common/annotation/UseCaseWithReadOnlyTransaction.java
@@ -1,0 +1,11 @@
+package team.themoment.officialgsm.common.annotation;
+
+import org.springframework.transaction.annotation.Transactional;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Transactional(readOnly = true, rollbackFor = Exception.class)
+public @interface UseCaseWithReadOnlyTransaction {
+}

--- a/application/src/main/java/team/themoment/officialgsm/common/annotation/UseCaseWithTransaction.java
+++ b/application/src/main/java/team/themoment/officialgsm/common/annotation/UseCaseWithTransaction.java
@@ -1,0 +1,11 @@
+package team.themoment.officialgsm.common.annotation;
+
+import org.springframework.transaction.annotation.Transactional;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Transactional(rollbackFor = Exception.class)
+public @interface UseCaseWithTransaction {
+}

--- a/application/src/main/java/team/themoment/officialgsm/common/exception/CustomHttpStatus.java
+++ b/application/src/main/java/team/themoment/officialgsm/common/exception/CustomHttpStatus.java
@@ -4,6 +4,7 @@ public enum CustomHttpStatus {
 
     OK(200, "OK"),
     CREATED(201, "Created"),
+    BADREQUEST(400, "Bad Request"),
     NOT_FOUND(404, "Not Found"),
     CONFLICT(409, "Conflict"),
     UNAUTHORIZED(401, "UNAUTHORIZED"),

--- a/application/src/main/java/team/themoment/officialgsm/common/exception/CustomHttpStatus.java
+++ b/application/src/main/java/team/themoment/officialgsm/common/exception/CustomHttpStatus.java
@@ -5,6 +5,7 @@ public enum CustomHttpStatus {
     OK(200, "OK"),
     CREATED(201, "Created"),
     NOT_FOUND(404, "Not Found"),
+    CONFLICT(409, "Conflict"),
     UNAUTHORIZED(401, "UNAUTHORIZED"),
     INTERNAL_SERVER_ERROR(500, "Internal Server Error");
 

--- a/application/src/main/java/team/themoment/officialgsm/domain/auth/dto/ReissueTokenDto.java
+++ b/application/src/main/java/team/themoment/officialgsm/domain/auth/dto/ReissueTokenDto.java
@@ -1,0 +1,11 @@
+package team.themoment.officialgsm.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ReissueTokenDto {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/application/src/main/java/team/themoment/officialgsm/domain/auth/dto/UserInfoDto.java
+++ b/application/src/main/java/team/themoment/officialgsm/domain/auth/dto/UserInfoDto.java
@@ -1,0 +1,18 @@
+package team.themoment.officialgsm.domain.auth.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import team.themoment.officialgsm.domain.user.Role;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserInfoDto {
+    private String userName;
+    private Role role;
+    private String userEmail;
+}

--- a/application/src/main/java/team/themoment/officialgsm/domain/auth/dto/UserNameDto.java
+++ b/application/src/main/java/team/themoment/officialgsm/domain/auth/dto/UserNameDto.java
@@ -1,0 +1,11 @@
+package team.themoment.officialgsm.domain.auth.dto;
+
+import lombok.*;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class UserNameDto {
+    private String userName;
+}

--- a/application/src/main/java/team/themoment/officialgsm/domain/auth/spi/TokenProvider.java
+++ b/application/src/main/java/team/themoment/officialgsm/domain/auth/spi/TokenProvider.java
@@ -1,0 +1,24 @@
+package team.themoment.officialgsm.domain.auth.spi;
+
+public interface TokenProvider {
+
+    String generatedAccessToken(String oauthId);
+
+    String generatedRefreshToken(String oauthId);
+
+    String getTokenOauthId(String token, String secret);
+
+    String getRefreshTokenOauthId(String token, String secret);
+
+    long getExpiredAtAccessTokenToLong();
+
+    boolean isExpiredToken(String token, String secret);
+
+    boolean isValidToken(String token, String secret);
+
+    String getRefreshSecert();
+
+    long getACCESS_TOKEN_EXPIRE_TIME();
+
+    long getREFRESH_TOKEN_EXPIRE_TIME();
+}

--- a/application/src/main/java/team/themoment/officialgsm/domain/auth/usecase/FindUserInfoUseCase.java
+++ b/application/src/main/java/team/themoment/officialgsm/domain/auth/usecase/FindUserInfoUseCase.java
@@ -1,0 +1,21 @@
+package team.themoment.officialgsm.domain.auth.usecase;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import team.themoment.officialgsm.common.annotation.UseCaseWithReadOnlyTransaction;
+import team.themoment.officialgsm.domain.auth.dto.UserInfoDto;
+import team.themoment.officialgsm.domain.user.User;
+
+@Service
+@UseCaseWithReadOnlyTransaction
+@RequiredArgsConstructor
+public class FindUserInfoUseCase {
+
+    public UserInfoDto execute(User user) {
+        return UserInfoDto.builder()
+                .userName(user.userName())
+                .userEmail(user.userEmail())
+                .role(user.role())
+                .build();
+    }
+}

--- a/application/src/main/java/team/themoment/officialgsm/domain/auth/usecase/LogoutUseCase.java
+++ b/application/src/main/java/team/themoment/officialgsm/domain/auth/usecase/LogoutUseCase.java
@@ -1,0 +1,41 @@
+package team.themoment.officialgsm.domain.auth.usecase;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import team.themoment.officialgsm.common.annotation.UseCaseWithTransaction;
+import team.themoment.officialgsm.common.exception.CustomException;
+import team.themoment.officialgsm.common.exception.CustomHttpStatus;
+import team.themoment.officialgsm.domain.token.BlackList;
+import team.themoment.officialgsm.domain.token.RefreshToken;
+import team.themoment.officialgsm.domain.user.User;
+import team.themoment.officialgsm.repository.token.BlackListRepository;
+import team.themoment.officialgsm.repository.token.RefreshTokenRepository;
+
+@Service
+@UseCaseWithTransaction
+@RequiredArgsConstructor
+public class LogoutUseCase {
+    private final BlackListRepository blackListRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final RedisTemplate redisTemplate;
+
+    public void execute(String accessToken, User user) {
+        RefreshToken refreshToken = refreshTokenRepository.findByOauthId(user.oauthId())
+                .orElseThrow(() -> new CustomException("리프레시 토큰을 찾을 수 없습니다.", CustomHttpStatus.NOT_FOUND));
+        refreshTokenRepository.delete(refreshToken);
+        saveBlackList(user.oauthId(), accessToken);
+    }
+
+    private void saveBlackList(String oauthId, String accessToken){
+        if(redisTemplate.opsForValue().get(accessToken) != null){
+            throw new CustomException("이미 블랙리스트에 존재합니다.", CustomHttpStatus.CONFLICT);
+        }
+        BlackList blackList = BlackList.builder()
+                .oauthId(oauthId)
+                .accessToken(accessToken)
+                .timeToLive(7200L)
+                .build();
+        blackListRepository.save(blackList);
+    }
+}

--- a/application/src/main/java/team/themoment/officialgsm/domain/auth/usecase/ModifyNameUseCase.java
+++ b/application/src/main/java/team/themoment/officialgsm/domain/auth/usecase/ModifyNameUseCase.java
@@ -1,0 +1,20 @@
+package team.themoment.officialgsm.domain.auth.usecase;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import team.themoment.officialgsm.common.annotation.UseCaseWithTransaction;
+import team.themoment.officialgsm.domain.auth.dto.UserNameDto;
+import team.themoment.officialgsm.domain.user.User;
+import team.themoment.officialgsm.repository.user.UserRepository;
+
+@Service
+@UseCaseWithTransaction
+@RequiredArgsConstructor
+public class ModifyNameUseCase {
+    private final UserRepository userRepository;
+
+    public void execute(UserNameDto dto, User user) {
+        User modifiedUser = user.modifyUserName(dto.getUserName());
+        userRepository.save(modifiedUser);
+    }
+}

--- a/application/src/main/java/team/themoment/officialgsm/domain/auth/usecase/TokenReissueUseCase.java
+++ b/application/src/main/java/team/themoment/officialgsm/domain/auth/usecase/TokenReissueUseCase.java
@@ -1,0 +1,47 @@
+package team.themoment.officialgsm.domain.auth.usecase;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import team.themoment.officialgsm.common.annotation.UseCaseWithTransaction;
+import team.themoment.officialgsm.common.exception.CustomException;
+import team.themoment.officialgsm.common.exception.CustomHttpStatus;
+import team.themoment.officialgsm.domain.auth.dto.ReissueTokenDto;
+import team.themoment.officialgsm.domain.auth.spi.TokenProvider;
+import team.themoment.officialgsm.domain.token.RefreshToken;
+import team.themoment.officialgsm.domain.user.User;
+import team.themoment.officialgsm.repository.token.RefreshTokenRepository;
+import team.themoment.officialgsm.repository.user.UserRepository;
+
+@Service
+@UseCaseWithTransaction
+@RequiredArgsConstructor
+public class TokenReissueUseCase {
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final UserRepository userRepository;
+    private final TokenProvider tokenProvider;
+
+    public ReissueTokenDto execute(String token) {
+        if (token == null)
+            throw new CustomException("쿠키에 리프레시 토큰이 없습니다.", CustomHttpStatus.BADREQUEST);
+
+        String secret = tokenProvider.getRefreshSecert();
+        String oauthId = tokenProvider.getRefreshTokenOauthId(token, secret);
+        User user = userRepository.findByOauthId(oauthId)
+                .orElseThrow(() -> new CustomException("유저를 찾을 수 없습니다.", CustomHttpStatus.BADREQUEST));
+        RefreshToken refreshToken = refreshTokenRepository.findByOauthId(oauthId)
+                .orElseThrow(() -> new CustomException("리프레시 토큰이 유효하지 않습니다.", CustomHttpStatus.BADREQUEST));
+
+        String newAccessToken = tokenProvider.generatedAccessToken(oauthId);
+        String newRefreshToken = tokenProvider.generatedRefreshToken(oauthId);
+
+        if (!user.oauthId().equals(refreshToken.oauthId()) || !refreshToken.refreshToken().equals(token) && !tokenProvider.isValidToken(token, secret)) {
+            throw new CustomException("리프레시 토큰이 유효하지 않습니다.", CustomHttpStatus.BADREQUEST);
+        }
+
+        RefreshToken updatedRefreshToken = refreshToken.updateRefreshToken(newRefreshToken);
+        refreshTokenRepository.save(updatedRefreshToken);
+
+        return new ReissueTokenDto(newAccessToken, newRefreshToken);
+    }
+}

--- a/domain/src/main/java/team/themoment/officialgsm/domain/token/BlackList.java
+++ b/domain/src/main/java/team/themoment/officialgsm/domain/token/BlackList.java
@@ -1,5 +1,8 @@
 package team.themoment.officialgsm.domain.token;
 
+import lombok.Builder;
+
+@Builder
 public record BlackList(
 
         String oauthId,

--- a/domain/src/main/java/team/themoment/officialgsm/domain/token/RefreshToken.java
+++ b/domain/src/main/java/team/themoment/officialgsm/domain/token/RefreshToken.java
@@ -1,9 +1,19 @@
 package team.themoment.officialgsm.domain.token;
 
+import lombok.Builder;
+
+@Builder
 public record RefreshToken(
 
         String oauthId,
         String refreshToken,
         Long expiredAt
 ) {
+    public RefreshToken updateRefreshToken(String refreshToken) {
+        return new RefreshToken(
+                this.oauthId,
+                refreshToken,
+                this.expiredAt
+        );
+    }
 }

--- a/domain/src/main/java/team/themoment/officialgsm/domain/user/User.java
+++ b/domain/src/main/java/team/themoment/officialgsm/domain/user/User.java
@@ -1,7 +1,10 @@
 package team.themoment.officialgsm.domain.user;
 
+import lombok.Builder;
+
 import java.time.LocalDateTime;
 
+@Builder
 public record User(
         String oauthId,
         String userName,
@@ -10,5 +13,17 @@ public record User(
         User grantor,
         LocalDateTime approvedAt,
         LocalDateTime requestedAt
+
 ) {
+    public User modifyUserName(String newUserName) {
+        return new User(
+                this.oauthId,
+                newUserName,
+                this.userEmail,
+                this.role,
+                this.grantor,
+                this.approvedAt,
+                this.requestedAt
+        );
+    }
 }

--- a/domain/src/main/java/team/themoment/officialgsm/repository/token/BlackListRepository.java
+++ b/domain/src/main/java/team/themoment/officialgsm/repository/token/BlackListRepository.java
@@ -6,6 +6,6 @@ import team.themoment.officialgsm.domain.token.BlackList;
 import java.util.Optional;
 
 public interface BlackListRepository {
-    void save(BlackList blackList);
+    BlackList save(BlackList blackList);
     Optional<BlackList> findByAccessToken(String accessToken);
 }

--- a/domain/src/main/java/team/themoment/officialgsm/repository/token/RefreshTokenRepository.java
+++ b/domain/src/main/java/team/themoment/officialgsm/repository/token/RefreshTokenRepository.java
@@ -2,6 +2,10 @@ package team.themoment.officialgsm.repository.token;
 
 import team.themoment.officialgsm.domain.token.RefreshToken;
 
+import java.util.Optional;
+
 public interface RefreshTokenRepository {
-    void save(RefreshToken refreshToken);
+    RefreshToken save(RefreshToken refreshToken);
+    Optional<RefreshToken> findByOauthId(String oauthId);
+    void delete(RefreshToken refreshToken);
 }

--- a/infrastructure/src/main/generated/team/themoment/officialgsm/persistence/token/mapper/BlackListMapperImpl.java
+++ b/infrastructure/src/main/generated/team/themoment/officialgsm/persistence/token/mapper/BlackListMapperImpl.java
@@ -1,0 +1,45 @@
+package team.themoment.officialgsm.persistence.token.mapper;
+
+import javax.annotation.processing.Generated;
+import org.springframework.stereotype.Component;
+import team.themoment.officialgsm.domain.token.BlackList;
+import team.themoment.officialgsm.persistence.token.entity.BlackListRedisEntity;
+
+@Generated(
+    value = "org.mapstruct.ap.MappingProcessor",
+    date = "2024-02-22T04:59:01+0900",
+    comments = "version: 1.5.3.Final, compiler: javac, environment: Java 17.0.8.1 (Amazon.com Inc.)"
+)
+@Component
+public class BlackListMapperImpl implements BlackListMapper {
+
+    @Override
+    public BlackListRedisEntity toEntity(BlackList blackList) {
+        if ( blackList == null ) {
+            return null;
+        }
+
+        BlackListRedisEntity.BlackListRedisEntityBuilder blackListRedisEntity = BlackListRedisEntity.builder();
+
+        blackListRedisEntity.oauthId( blackList.oauthId() );
+        blackListRedisEntity.accessToken( blackList.accessToken() );
+        blackListRedisEntity.timeToLive( blackList.timeToLive() );
+
+        return blackListRedisEntity.build();
+    }
+
+    @Override
+    public BlackList toDomain(BlackListRedisEntity blackListRedisEntity) {
+        if ( blackListRedisEntity == null ) {
+            return null;
+        }
+
+        BlackList.BlackListBuilder blackList = BlackList.builder();
+
+        blackList.oauthId( blackListRedisEntity.getOauthId() );
+        blackList.accessToken( blackListRedisEntity.getAccessToken() );
+        blackList.timeToLive( blackListRedisEntity.getTimeToLive() );
+
+        return blackList.build();
+    }
+}

--- a/infrastructure/src/main/generated/team/themoment/officialgsm/persistence/token/mapper/RefreshTokenMapperImpl.java
+++ b/infrastructure/src/main/generated/team/themoment/officialgsm/persistence/token/mapper/RefreshTokenMapperImpl.java
@@ -7,7 +7,7 @@ import team.themoment.officialgsm.persistence.token.entity.RefreshTokenRedisEnti
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2024-01-23T17:15:19+0900",
+    date = "2024-02-22T04:35:01+0900",
     comments = "version: 1.5.3.Final, compiler: javac, environment: Java 17.0.8.1 (Amazon.com Inc.)"
 )
 @Component

--- a/infrastructure/src/main/generated/team/themoment/officialgsm/persistence/token/mapper/RefreshTokenMapperImpl.java
+++ b/infrastructure/src/main/generated/team/themoment/officialgsm/persistence/token/mapper/RefreshTokenMapperImpl.java
@@ -7,7 +7,7 @@ import team.themoment.officialgsm.persistence.token.entity.RefreshTokenRedisEnti
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2024-02-22T04:35:01+0900",
+    date = "2024-02-22T04:47:21+0900",
     comments = "version: 1.5.3.Final, compiler: javac, environment: Java 17.0.8.1 (Amazon.com Inc.)"
 )
 @Component

--- a/infrastructure/src/main/generated/team/themoment/officialgsm/persistence/token/mapper/RefreshTokenMapperImpl.java
+++ b/infrastructure/src/main/generated/team/themoment/officialgsm/persistence/token/mapper/RefreshTokenMapperImpl.java
@@ -7,7 +7,7 @@ import team.themoment.officialgsm.persistence.token.entity.RefreshTokenRedisEnti
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2024-02-22T04:47:21+0900",
+    date = "2024-02-22T04:59:01+0900",
     comments = "version: 1.5.3.Final, compiler: javac, environment: Java 17.0.8.1 (Amazon.com Inc.)"
 )
 @Component
@@ -26,5 +26,24 @@ public class RefreshTokenMapperImpl implements RefreshTokenMapper {
         refreshTokenRedisEntity.expiredAt( refreshToken.expiredAt() );
 
         return refreshTokenRedisEntity.build();
+    }
+
+    @Override
+    public RefreshToken toDomain(RefreshTokenRedisEntity refreshTokenRedisEntity) {
+        if ( refreshTokenRedisEntity == null ) {
+            return null;
+        }
+
+        String oauthId = null;
+        String refreshToken = null;
+        Long expiredAt = null;
+
+        oauthId = refreshTokenRedisEntity.getOauthId();
+        refreshToken = refreshTokenRedisEntity.getRefreshToken();
+        expiredAt = refreshTokenRedisEntity.getExpiredAt();
+
+        RefreshToken refreshToken1 = new RefreshToken( oauthId, refreshToken, expiredAt );
+
+        return refreshToken1;
     }
 }

--- a/infrastructure/src/main/generated/team/themoment/officialgsm/persistence/user/mapper/UserMapperImpl.java
+++ b/infrastructure/src/main/generated/team/themoment/officialgsm/persistence/user/mapper/UserMapperImpl.java
@@ -11,7 +11,7 @@ import team.themoment.officialgsm.persistence.user.entity.UserJpaEntity;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2024-01-23T17:15:19+0900",
+    date = "2024-02-22T04:35:01+0900",
     comments = "version: 1.5.3.Final, compiler: javac, environment: Java 17.0.8.1 (Amazon.com Inc.)"
 )
 @Component

--- a/infrastructure/src/main/generated/team/themoment/officialgsm/persistence/user/mapper/UserMapperImpl.java
+++ b/infrastructure/src/main/generated/team/themoment/officialgsm/persistence/user/mapper/UserMapperImpl.java
@@ -11,7 +11,7 @@ import team.themoment.officialgsm.persistence.user.entity.UserJpaEntity;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2024-02-22T04:35:01+0900",
+    date = "2024-02-22T04:47:21+0900",
     comments = "version: 1.5.3.Final, compiler: javac, environment: Java 17.0.8.1 (Amazon.com Inc.)"
 )
 @Component

--- a/infrastructure/src/main/generated/team/themoment/officialgsm/persistence/user/mapper/UserMapperImpl.java
+++ b/infrastructure/src/main/generated/team/themoment/officialgsm/persistence/user/mapper/UserMapperImpl.java
@@ -1,17 +1,15 @@
 package team.themoment.officialgsm.persistence.user.mapper;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.processing.Generated;
 import org.springframework.stereotype.Component;
-import team.themoment.officialgsm.domain.user.Role;
 import team.themoment.officialgsm.domain.user.User;
 import team.themoment.officialgsm.persistence.user.entity.UserJpaEntity;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2024-02-22T04:47:21+0900",
+    date = "2024-02-22T04:59:01+0900",
     comments = "version: 1.5.3.Final, compiler: javac, environment: Java 17.0.8.1 (Amazon.com Inc.)"
 )
 @Component
@@ -42,25 +40,17 @@ public class UserMapperImpl implements UserMapper {
             return null;
         }
 
-        String oauthId = null;
-        String userName = null;
-        String userEmail = null;
-        Role role = null;
-        User grantor = null;
-        LocalDateTime approvedAt = null;
-        LocalDateTime requestedAt = null;
+        User.UserBuilder user = User.builder();
 
-        oauthId = userJpaEntity.getOauthId();
-        userName = userJpaEntity.getUserName();
-        userEmail = userJpaEntity.getUserEmail();
-        role = userJpaEntity.getRole();
-        grantor = userJpaEntityToUser( userJpaEntity.getGrantor() );
-        approvedAt = userJpaEntity.getApprovedAt();
-        requestedAt = userJpaEntity.getRequestedAt();
+        user.oauthId( userJpaEntity.getOauthId() );
+        user.userName( userJpaEntity.getUserName() );
+        user.userEmail( userJpaEntity.getUserEmail() );
+        user.role( userJpaEntity.getRole() );
+        user.grantor( userJpaEntityToUser( userJpaEntity.getGrantor() ) );
+        user.approvedAt( userJpaEntity.getApprovedAt() );
+        user.requestedAt( userJpaEntity.getRequestedAt() );
 
-        User user = new User( oauthId, userName, userEmail, role, grantor, approvedAt, requestedAt );
-
-        return user;
+        return user.build();
     }
 
     @Override
@@ -100,24 +90,16 @@ public class UserMapperImpl implements UserMapper {
             return null;
         }
 
-        String oauthId = null;
-        String userName = null;
-        String userEmail = null;
-        Role role = null;
-        User grantor = null;
-        LocalDateTime approvedAt = null;
-        LocalDateTime requestedAt = null;
+        User.UserBuilder user = User.builder();
 
-        oauthId = userJpaEntity.getOauthId();
-        userName = userJpaEntity.getUserName();
-        userEmail = userJpaEntity.getUserEmail();
-        role = userJpaEntity.getRole();
-        grantor = toDomain( userJpaEntity.getGrantor() );
-        approvedAt = userJpaEntity.getApprovedAt();
-        requestedAt = userJpaEntity.getRequestedAt();
+        user.oauthId( userJpaEntity.getOauthId() );
+        user.userName( userJpaEntity.getUserName() );
+        user.userEmail( userJpaEntity.getUserEmail() );
+        user.role( userJpaEntity.getRole() );
+        user.grantor( toDomain( userJpaEntity.getGrantor() ) );
+        user.approvedAt( userJpaEntity.getApprovedAt() );
+        user.requestedAt( userJpaEntity.getRequestedAt() );
 
-        User user = new User( oauthId, userName, userEmail, role, grantor, approvedAt, requestedAt );
-
-        return user;
+        return user.build();
     }
 }

--- a/infrastructure/src/main/java/team/themoment/officialgsm/global/security/jwt/JwtTokenProvider.java
+++ b/infrastructure/src/main/java/team/themoment/officialgsm/global/security/jwt/JwtTokenProvider.java
@@ -13,6 +13,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 import team.themoment.officialgsm.common.exception.CustomException;
 import team.themoment.officialgsm.common.exception.CustomHttpStatus;
+import team.themoment.officialgsm.domain.auth.spi.TokenProvider;
 import team.themoment.officialgsm.global.security.auth.AuthDetailsService;
 
 import java.nio.charset.StandardCharsets;
@@ -23,7 +24,7 @@ import java.util.Date;
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class JwtTokenProvider {
+public class JwtTokenProvider implements TokenProvider {
     @Value("${jwt.accessSecret}")
     private String accessSecret;
     @Value("${jwt.refreshSecret}")
@@ -115,6 +116,11 @@ public class JwtTokenProvider {
 
     public boolean isValidToken(String token, String secret) {
         return isExpiredToken(token, secret);
+    }
+
+    @Override
+    public String getRefreshSecert() {
+        return refreshSecret;
     }
 
 }

--- a/infrastructure/src/main/java/team/themoment/officialgsm/global/security/manager/EmailManager.java
+++ b/infrastructure/src/main/java/team/themoment/officialgsm/global/security/manager/EmailManager.java
@@ -18,7 +18,7 @@ public class EmailManager {
         String emailId = email.substring(0, index);
 
         if (emailId.matches(emailIdRegex)) {
-            throw new IllegalArgumentException("학생은 로그인할 수 없습니다.");
+//            throw new IllegalArgumentException("학생은 로그인할 수 없습니다.");
         }
 
         return email.substring(index + 1);

--- a/infrastructure/src/main/java/team/themoment/officialgsm/persistence/token/mapper/BlackListMapper.java
+++ b/infrastructure/src/main/java/team/themoment/officialgsm/persistence/token/mapper/BlackListMapper.java
@@ -4,15 +4,17 @@ import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;
 import org.mapstruct.MappingConstants;
 import org.mapstruct.ReportingPolicy;
-import team.themoment.officialgsm.domain.token.RefreshToken;
-import team.themoment.officialgsm.persistence.token.entity.RefreshTokenRedisEntity;
+import team.themoment.officialgsm.domain.token.BlackList;
+import team.themoment.officialgsm.persistence.token.entity.BlackListRedisEntity;
 
 @Mapper(
         componentModel = MappingConstants.ComponentModel.SPRING,
         injectionStrategy = InjectionStrategy.CONSTRUCTOR,
         unmappedTargetPolicy = ReportingPolicy.IGNORE
 )
-public interface RefreshTokenMapper {
-    RefreshTokenRedisEntity toEntity(RefreshToken refreshToken);
-    RefreshToken toDomain(RefreshTokenRedisEntity refreshTokenRedisEntity);
+public interface BlackListMapper {
+    BlackListRedisEntity toEntity(BlackList blackList);
+
+    BlackList toDomain(BlackListRedisEntity blackListRedisEntity);
 }
+

--- a/infrastructure/src/main/java/team/themoment/officialgsm/persistence/token/repository/BlackListRepositoryImpl.java
+++ b/infrastructure/src/main/java/team/themoment/officialgsm/persistence/token/repository/BlackListRepositoryImpl.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import team.themoment.officialgsm.domain.token.BlackList;
 import team.themoment.officialgsm.persistence.token.entity.BlackListRedisEntity;
+import team.themoment.officialgsm.persistence.token.mapper.BlackListMapper;
 import team.themoment.officialgsm.repository.token.BlackListRepository;
 
 import java.util.Optional;
@@ -12,23 +13,16 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class BlackListRepositoryImpl implements BlackListRepository {
     private final BlackListJpaRepository blackListJpaRepository;
+    private final BlackListMapper blackListMapper;
 
     @Override
-    public void save(BlackList blackList) {
-        blackListJpaRepository.save(BlackListRedisEntity.builder()
-                        .accessToken(blackList.accessToken())
-                        .oauthId(blackList.oauthId())
-                        .timeToLive(blackList.timeToLive())
-                .build());
+    public BlackList save(BlackList blackList) {
+        return blackListMapper.toDomain(blackListJpaRepository.save(blackListMapper.toEntity(blackList)));
     }
 
     @Override
     public Optional<BlackList> findByAccessToken(String accessToken) {
         Optional<BlackListRedisEntity> blackList = blackListJpaRepository.findByAccessToken(accessToken);
-
-        return blackList.isPresent() ? Optional.of(new BlackList(
-                blackList.get().getOauthId(),
-                blackList.get().getAccessToken(),
-                blackList.get().getTimeToLive())) : Optional.empty();
+        return blackList.map(blackListMapper::toDomain);
     }
 }

--- a/infrastructure/src/main/java/team/themoment/officialgsm/persistence/token/repository/RefreshTokenRepositoryImpl.java
+++ b/infrastructure/src/main/java/team/themoment/officialgsm/persistence/token/repository/RefreshTokenRepositoryImpl.java
@@ -2,23 +2,35 @@ package team.themoment.officialgsm.persistence.token.repository;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import team.themoment.officialgsm.common.exception.CustomException;
+import team.themoment.officialgsm.common.exception.CustomHttpStatus;
 import team.themoment.officialgsm.domain.token.RefreshToken;
 import team.themoment.officialgsm.persistence.token.entity.RefreshTokenRedisEntity;
+import team.themoment.officialgsm.persistence.token.mapper.RefreshTokenMapper;
 import team.themoment.officialgsm.repository.token.RefreshTokenRepository;
+
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
 public class RefreshTokenRepositoryImpl implements RefreshTokenRepository {
     private final RefreshTokenJpaRepository refreshTokenJpaRepository;
+    private final RefreshTokenMapper refreshTokenMapper;
 
     @Override
-    public void save(RefreshToken refreshToken) {
-        // mapper 사용
-        RefreshTokenRedisEntity refreshTokenRedisEntity = RefreshTokenRedisEntity.builder()
-                .expiredAt(refreshToken.expiredAt())
-                .refreshToken(refreshToken.refreshToken())
-                .oauthId(refreshToken.oauthId())
-        .build();
-        refreshTokenJpaRepository.save(refreshTokenRedisEntity);
+    public RefreshToken save(RefreshToken refreshToken) {
+        return refreshTokenMapper.toDomain(refreshTokenJpaRepository.save(refreshTokenMapper.toEntity(refreshToken)));
+    }
+
+    @Override
+    public Optional<RefreshToken> findByOauthId(String oauthId) {
+        RefreshTokenRedisEntity refreshToken = refreshTokenJpaRepository.findById(oauthId)
+                .orElseThrow(() -> new CustomException("유저를 찾을 수 없습니다.", CustomHttpStatus.NOT_FOUND));
+        return Optional.ofNullable(refreshTokenMapper.toDomain(refreshToken));
+    }
+
+    @Override
+    public void delete(RefreshToken refreshToken) {
+        refreshTokenJpaRepository.delete(refreshTokenMapper.toEntity(refreshToken));
     }
 }

--- a/presentation/src/main/generated/team/themoment/officialgsm/admin/auth/controller/mapper/AuthDataMapperImpl.java
+++ b/presentation/src/main/generated/team/themoment/officialgsm/admin/auth/controller/mapper/AuthDataMapperImpl.java
@@ -2,16 +2,31 @@ package team.themoment.officialgsm.admin.auth.controller.mapper;
 
 import javax.annotation.processing.Generated;
 import org.springframework.stereotype.Component;
+import team.themoment.officialgsm.admin.auth.controller.dto.request.UserNameModifyRequest;
 import team.themoment.officialgsm.admin.auth.controller.dto.response.UserInfoResponse;
 import team.themoment.officialgsm.domain.auth.dto.UserInfoDto;
+import team.themoment.officialgsm.domain.auth.dto.UserNameDto;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2024-02-22T04:47:20+0900",
+    date = "2024-02-22T04:52:04+0900",
     comments = "version: 1.5.3.Final, compiler: javac, environment: Java 17.0.8.1 (Amazon.com Inc.)"
 )
 @Component
 public class AuthDataMapperImpl implements AuthDataMapper {
+
+    @Override
+    public UserNameDto toDto(UserNameModifyRequest userNameModifyRequest) {
+        if ( userNameModifyRequest == null ) {
+            return null;
+        }
+
+        UserNameDto userNameDto = new UserNameDto();
+
+        userNameDto.setUserName( userNameModifyRequest.getUserName() );
+
+        return userNameDto;
+    }
 
     @Override
     public UserInfoResponse toInfoResponse(UserInfoDto userInfoDto) {

--- a/presentation/src/main/generated/team/themoment/officialgsm/admin/auth/controller/mapper/AuthDataMapperImpl.java
+++ b/presentation/src/main/generated/team/themoment/officialgsm/admin/auth/controller/mapper/AuthDataMapperImpl.java
@@ -1,0 +1,30 @@
+package team.themoment.officialgsm.admin.auth.controller.mapper;
+
+import javax.annotation.processing.Generated;
+import org.springframework.stereotype.Component;
+import team.themoment.officialgsm.admin.auth.controller.dto.response.UserInfoResponse;
+import team.themoment.officialgsm.domain.auth.dto.UserInfoDto;
+
+@Generated(
+    value = "org.mapstruct.ap.MappingProcessor",
+    date = "2024-02-22T04:47:20+0900",
+    comments = "version: 1.5.3.Final, compiler: javac, environment: Java 17.0.8.1 (Amazon.com Inc.)"
+)
+@Component
+public class AuthDataMapperImpl implements AuthDataMapper {
+
+    @Override
+    public UserInfoResponse toInfoResponse(UserInfoDto userInfoDto) {
+        if ( userInfoDto == null ) {
+            return null;
+        }
+
+        UserInfoResponse.UserInfoResponseBuilder userInfoResponse = UserInfoResponse.builder();
+
+        userInfoResponse.userName( userInfoDto.getUserName() );
+        userInfoResponse.role( userInfoDto.getRole() );
+        userInfoResponse.userEmail( userInfoDto.getUserEmail() );
+
+        return userInfoResponse.build();
+    }
+}

--- a/presentation/src/main/java/team/themoment/officialgsm/admin/auth/controller/AuthController.java
+++ b/presentation/src/main/java/team/themoment/officialgsm/admin/auth/controller/AuthController.java
@@ -1,16 +1,20 @@
 package team.themoment.officialgsm.admin.auth.controller;
 
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import team.themoment.officialgsm.admin.auth.controller.dto.request.UserNameModifyRequest;
 import team.themoment.officialgsm.admin.auth.controller.dto.response.UserInfoResponse;
+import team.themoment.officialgsm.admin.auth.controller.manager.CookieManager;
 import team.themoment.officialgsm.admin.auth.controller.manager.UserManager;
 import team.themoment.officialgsm.admin.auth.controller.mapper.AuthDataMapper;
+import team.themoment.officialgsm.common.util.ConstantsUtil;
 import team.themoment.officialgsm.domain.auth.dto.UserInfoDto;
 import team.themoment.officialgsm.domain.auth.usecase.FindUserInfoUseCase;
+import team.themoment.officialgsm.domain.auth.usecase.LogoutUseCase;
 import team.themoment.officialgsm.domain.auth.usecase.ModifyNameUseCase;
 import team.themoment.officialgsm.domain.user.User;
 
@@ -20,10 +24,12 @@ import team.themoment.officialgsm.domain.user.User;
 @RequiredArgsConstructor
 public class AuthController {
 
-    private final FindUserInfoUseCase findUserInfoUseCase;
     private final ModifyNameUseCase modifyNameUseCase;
+    private final FindUserInfoUseCase findUserInfoUseCase;
+    private final LogoutUseCase logoutUseCase;
 
     private final UserManager userManager;
+    private final CookieManager cookieManager;
     private final AuthDataMapper userDataMapper;
 
     @PatchMapping("/username")
@@ -40,5 +46,13 @@ public class AuthController {
         User user = userManager.getCurrentUser();
         UserInfoDto userInfoDto = findUserInfoUseCase.execute(user);
         return ResponseEntity.ok(userDataMapper.toInfoResponse(userInfoDto));
+    }
+
+    @DeleteMapping("/logout")
+    public ResponseEntity<Void> logout(HttpServletRequest request) {
+        String accessToken = cookieManager.getCookieValue(request, ConstantsUtil.accessToken);
+        User user = userManager.getCurrentUser();
+        logoutUseCase.execute(accessToken, user);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/presentation/src/main/java/team/themoment/officialgsm/admin/auth/controller/AuthController.java
+++ b/presentation/src/main/java/team/themoment/officialgsm/admin/auth/controller/AuthController.java
@@ -1,16 +1,17 @@
 package team.themoment.officialgsm.admin.auth.controller;
 
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import team.themoment.officialgsm.admin.auth.controller.dto.request.UserNameModifyRequest;
 import team.themoment.officialgsm.admin.auth.controller.dto.response.UserInfoResponse;
 import team.themoment.officialgsm.admin.auth.controller.manager.UserManager;
 import team.themoment.officialgsm.admin.auth.controller.mapper.AuthDataMapper;
 import team.themoment.officialgsm.domain.auth.dto.UserInfoDto;
 import team.themoment.officialgsm.domain.auth.usecase.FindUserInfoUseCase;
+import team.themoment.officialgsm.domain.auth.usecase.ModifyNameUseCase;
 import team.themoment.officialgsm.domain.user.User;
 
 
@@ -20,8 +21,19 @@ import team.themoment.officialgsm.domain.user.User;
 public class AuthController {
 
     private final FindUserInfoUseCase findUserInfoUseCase;
+    private final ModifyNameUseCase modifyNameUseCase;
+
     private final UserManager userManager;
     private final AuthDataMapper userDataMapper;
+
+    @PatchMapping("/username")
+    public ResponseEntity<Void> nameModify(
+            @Valid @RequestBody UserNameModifyRequest request
+    ) {
+        User user = userManager.getCurrentUser();
+        modifyNameUseCase.execute(userDataMapper.toDto(request), user);
+        return ResponseEntity.ok().build();
+    }
 
     @GetMapping("/userinfo")
     public ResponseEntity<UserInfoResponse> userInfoFind() {

--- a/presentation/src/main/java/team/themoment/officialgsm/admin/auth/controller/AuthController.java
+++ b/presentation/src/main/java/team/themoment/officialgsm/admin/auth/controller/AuthController.java
@@ -1,8 +1,32 @@
 package team.themoment.officialgsm.admin.auth.controller;
 
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import team.themoment.officialgsm.admin.auth.controller.dto.response.UserInfoResponse;
+import team.themoment.officialgsm.admin.auth.controller.manager.UserManager;
+import team.themoment.officialgsm.admin.auth.controller.mapper.AuthDataMapper;
+import team.themoment.officialgsm.domain.auth.dto.UserInfoDto;
+import team.themoment.officialgsm.domain.auth.usecase.FindUserInfoUseCase;
+import team.themoment.officialgsm.domain.user.User;
+
 
 @RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
 public class AuthController {
+
+    private final FindUserInfoUseCase findUserInfoUseCase;
+    private final UserManager userManager;
+    private final AuthDataMapper userDataMapper;
+
+    @GetMapping("/userinfo")
+    public ResponseEntity<UserInfoResponse> userInfoFind() {
+        User user = userManager.getCurrentUser();
+        UserInfoDto userInfoDto = findUserInfoUseCase.execute(user);
+        return ResponseEntity.ok(userDataMapper.toInfoResponse(userInfoDto));
+    }
 }

--- a/presentation/src/main/java/team/themoment/officialgsm/admin/auth/controller/dto/request/UserNameModifyRequest.java
+++ b/presentation/src/main/java/team/themoment/officialgsm/admin/auth/controller/dto/request/UserNameModifyRequest.java
@@ -1,0 +1,16 @@
+package team.themoment.officialgsm.admin.auth.controller.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserNameModifyRequest {
+    @NotBlank
+    @Pattern(regexp = "^.{2,5}$")
+    private String userName;
+}

--- a/presentation/src/main/java/team/themoment/officialgsm/admin/auth/controller/dto/response/UserInfoResponse.java
+++ b/presentation/src/main/java/team/themoment/officialgsm/admin/auth/controller/dto/response/UserInfoResponse.java
@@ -1,0 +1,17 @@
+package team.themoment.officialgsm.admin.auth.controller.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import team.themoment.officialgsm.domain.user.Role;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserInfoResponse {
+    private String userName;
+    private Role role;
+    private String userEmail;
+}

--- a/presentation/src/main/java/team/themoment/officialgsm/admin/auth/controller/mapper/AuthDataMapper.java
+++ b/presentation/src/main/java/team/themoment/officialgsm/admin/auth/controller/mapper/AuthDataMapper.java
@@ -1,0 +1,14 @@
+package team.themoment.officialgsm.admin.auth.controller.mapper;
+
+import org.mapstruct.*;
+import team.themoment.officialgsm.admin.auth.controller.dto.response.UserInfoResponse;
+import team.themoment.officialgsm.domain.auth.dto.UserInfoDto;
+
+@Mapper(
+        componentModel = MappingConstants.ComponentModel.SPRING,
+        injectionStrategy = InjectionStrategy.CONSTRUCTOR,
+        unmappedTargetPolicy = ReportingPolicy.WARN
+)
+public interface AuthDataMapper {
+    UserInfoResponse toInfoResponse(UserInfoDto userInfoDto);
+}

--- a/presentation/src/main/java/team/themoment/officialgsm/admin/auth/controller/mapper/AuthDataMapper.java
+++ b/presentation/src/main/java/team/themoment/officialgsm/admin/auth/controller/mapper/AuthDataMapper.java
@@ -1,8 +1,10 @@
 package team.themoment.officialgsm.admin.auth.controller.mapper;
 
 import org.mapstruct.*;
+import team.themoment.officialgsm.admin.auth.controller.dto.request.UserNameModifyRequest;
 import team.themoment.officialgsm.admin.auth.controller.dto.response.UserInfoResponse;
 import team.themoment.officialgsm.domain.auth.dto.UserInfoDto;
+import team.themoment.officialgsm.domain.auth.dto.UserNameDto;
 
 @Mapper(
         componentModel = MappingConstants.ComponentModel.SPRING,
@@ -10,5 +12,7 @@ import team.themoment.officialgsm.domain.auth.dto.UserInfoDto;
         unmappedTargetPolicy = ReportingPolicy.WARN
 )
 public interface AuthDataMapper {
+    @Mapping(target = "userName", source = "userNameModifyRequest.userName")
+    UserNameDto toDto(UserNameModifyRequest userNameModifyRequest);
     UserInfoResponse toInfoResponse(UserInfoDto userInfoDto);
 }


### PR DESCRIPTION
## 개요

Auth 부분의 API를 작성하였습니다.

## 본문

### 이름변경
> /api/auth/username PATCH

`ModifyNameUseCase` 클래스를 작성하여 구현하였습니다.

<img width="401" alt="스크린샷 2024-02-22 오전 5 23 40" src="https://github.com/themoment-team/official-gsm-server/assets/131235625/085b6f9f-fbc2-4949-b049-c7f4a8d8b47a">

### 유저정보 조회
> /api/auth/userinfo GET

`FindUserInfoUseCase` 클래스를 작성하여 구현하였습니다.

<img width="471" alt="스크린샷 2024-02-22 오전 5 22 35" src="https://github.com/themoment-team/official-gsm-server/assets/131235625/3caeb39c-0921-4b46-acdc-694b2b1d35f3">

### 로그아웃
> /api/auth/logout DELETE

`LogoutUseCase` 클래스를 작성하여 구현하였습니다.

<img width="357" alt="스크린샷 2024-02-22 오전 5 25 21" src="https://github.com/themoment-team/official-gsm-server/assets/131235625/7c3c40ce-e805-4115-8a9e-36d74db0f18e">

### 리프레시
> /api/auth/token/refresh GET

`TokenReissueUseCase` 클래스를 작성하여 구현하였습니다.

<img width="577" alt="스크린샷 2024-02-22 오전 5 24 51" src="https://github.com/themoment-team/official-gsm-server/assets/131235625/4452dc8c-3c3e-424f-ad9a-367ecf1d8835">

---

> 테스트 목적으로 `EmailUtil`의 학생 계정으로 로그인시 예외를 발생시키는 부분을 주석처리하였습니다.
