### PR TITLE
feature/approve

### DIFF
--- a/application/src/main/java/team/themoment/officialgsm/domain/approve/dto/UnapprovedListDto.java
+++ b/application/src/main/java/team/themoment/officialgsm/domain/approve/dto/UnapprovedListDto.java
@@ -1,0 +1,20 @@
+package team.themoment.officialgsm.domain.approve.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import team.themoment.officialgsm.domain.user.Role;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class UnapprovedListDto {
+    private String userSeq;
+    private String userName;
+    private Role role;
+    private LocalDateTime requestedAt;
+}

--- a/application/src/main/java/team/themoment/officialgsm/domain/approve/usecase/ApprovedUseCase.java
+++ b/application/src/main/java/team/themoment/officialgsm/domain/approve/usecase/ApprovedUseCase.java
@@ -17,7 +17,7 @@ public class ApprovedUseCase {
     private final UserRepository userRepository;
 
     public void execute(String oauthId, User grantor) {
-        User user = userRepository.findByOauthId(oauthId)
+        User user = userRepository.findByOauthIdAndUserNameNotNull(oauthId)
                 .orElseThrow(() -> new CustomException("유저를 찾을 수 없습니다.", CustomHttpStatus.NOT_FOUND));
         LocalDateTime approvedAt = LocalDateTime.now();
        User approvedUser = user.approvedExecute(grantor, approvedAt);

--- a/application/src/main/java/team/themoment/officialgsm/domain/approve/usecase/ApprovedUseCase.java
+++ b/application/src/main/java/team/themoment/officialgsm/domain/approve/usecase/ApprovedUseCase.java
@@ -1,0 +1,26 @@
+package team.themoment.officialgsm.domain.approve.usecase;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import team.themoment.officialgsm.common.annotation.UseCaseWithTransaction;
+import team.themoment.officialgsm.common.exception.CustomException;
+import team.themoment.officialgsm.common.exception.CustomHttpStatus;
+import team.themoment.officialgsm.domain.user.User;
+import team.themoment.officialgsm.repository.user.UserRepository;
+
+import java.time.LocalDateTime;
+
+@Service
+@UseCaseWithTransaction
+@RequiredArgsConstructor
+public class ApprovedUseCase {
+    private final UserRepository userRepository;
+
+    public void execute(String oauthId, User grantor) {
+        User user = userRepository.findByOauthId(oauthId)
+                .orElseThrow(() -> new CustomException("유저를 찾을 수 없습니다.", CustomHttpStatus.NOT_FOUND));
+        LocalDateTime approvedAt = LocalDateTime.now();
+       User approvedUser = user.approvedExecute(grantor, approvedAt);
+       userRepository.save(approvedUser);
+    }
+}

--- a/application/src/main/java/team/themoment/officialgsm/domain/approve/usecase/RefuseApprovedUseCase.java
+++ b/application/src/main/java/team/themoment/officialgsm/domain/approve/usecase/RefuseApprovedUseCase.java
@@ -1,0 +1,22 @@
+package team.themoment.officialgsm.domain.approve.usecase;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import team.themoment.officialgsm.common.annotation.UseCaseWithTransaction;
+import team.themoment.officialgsm.common.exception.CustomException;
+import team.themoment.officialgsm.common.exception.CustomHttpStatus;
+import team.themoment.officialgsm.domain.user.User;
+import team.themoment.officialgsm.repository.user.UserRepository;
+
+@Service
+@UseCaseWithTransaction
+@RequiredArgsConstructor
+public class RefuseApprovedUseCase {
+    private final UserRepository userRepository;
+
+    public void execute(String oauthId) {
+        User user = userRepository.findByOauthIdAndUserNameNotNull(oauthId)
+                .orElseThrow(() -> new CustomException("유저를 찾을 수 없습니다.", CustomHttpStatus.NOT_FOUND));
+        userRepository.delete(user);
+    }
+}

--- a/application/src/main/java/team/themoment/officialgsm/domain/approve/usecase/UnapprovedListUseCase.java
+++ b/application/src/main/java/team/themoment/officialgsm/domain/approve/usecase/UnapprovedListUseCase.java
@@ -1,0 +1,27 @@
+package team.themoment.officialgsm.domain.approve.usecase;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import team.themoment.officialgsm.common.annotation.UseCaseWithTransaction;
+import team.themoment.officialgsm.domain.approve.dto.UnapprovedListDto;
+import team.themoment.officialgsm.domain.user.Role;
+import team.themoment.officialgsm.repository.user.UserRepository;
+
+import java.util.List;
+
+@Service
+@UseCaseWithTransaction
+@RequiredArgsConstructor
+public class UnapprovedListUseCase {
+    private final UserRepository userRepository;
+
+    public List<UnapprovedListDto> execute() {
+        return userRepository.findAllByRoleAndUserNameNotNull(Role.UNAPPROVED).stream()
+                .map(user -> UnapprovedListDto.builder()
+                        .userSeq(user.oauthId())
+                        .userName(user.userName())
+                        .role(user.role())
+                        .requestedAt(user.requestedAt())
+                        .build()).toList();
+    }
+}

--- a/domain/src/main/java/team/themoment/officialgsm/domain/user/User.java
+++ b/domain/src/main/java/team/themoment/officialgsm/domain/user/User.java
@@ -26,4 +26,16 @@ public record User(
                 this.requestedAt
         );
     }
+
+    public User approvedExecute(User grantor, LocalDateTime approvedAt) {
+        return new User(
+                this.oauthId,
+                this.userName,
+                this.userEmail,
+                Role.ADMIN,
+                grantor,
+                approvedAt,
+                this.requestedAt
+        );
+    }
 }

--- a/domain/src/main/java/team/themoment/officialgsm/repository/user/UserRepository.java
+++ b/domain/src/main/java/team/themoment/officialgsm/repository/user/UserRepository.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 public interface UserRepository {
     User save(User user);
     Optional<User> findByOauthId(String oauthId);
+    Optional<User> findByOauthIdAndUserNameNotNull(String oauthId);
     void deleteAll();
     void delete(User user);
     List<User> findAllByRoleAndUserNameNotNull(Role role);

--- a/infrastructure/src/main/generated/team/themoment/officialgsm/persistence/token/mapper/BlackListMapperImpl.java
+++ b/infrastructure/src/main/generated/team/themoment/officialgsm/persistence/token/mapper/BlackListMapperImpl.java
@@ -7,7 +7,7 @@ import team.themoment.officialgsm.persistence.token.entity.BlackListRedisEntity;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2024-02-22T04:59:01+0900",
+    date = "2024-02-28T02:07:41+0900",
     comments = "version: 1.5.3.Final, compiler: javac, environment: Java 17.0.8.1 (Amazon.com Inc.)"
 )
 @Component

--- a/infrastructure/src/main/generated/team/themoment/officialgsm/persistence/token/mapper/RefreshTokenMapperImpl.java
+++ b/infrastructure/src/main/generated/team/themoment/officialgsm/persistence/token/mapper/RefreshTokenMapperImpl.java
@@ -7,7 +7,7 @@ import team.themoment.officialgsm.persistence.token.entity.RefreshTokenRedisEnti
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2024-02-22T04:59:01+0900",
+    date = "2024-02-28T02:07:41+0900",
     comments = "version: 1.5.3.Final, compiler: javac, environment: Java 17.0.8.1 (Amazon.com Inc.)"
 )
 @Component
@@ -34,16 +34,12 @@ public class RefreshTokenMapperImpl implements RefreshTokenMapper {
             return null;
         }
 
-        String oauthId = null;
-        String refreshToken = null;
-        Long expiredAt = null;
+        RefreshToken.RefreshTokenBuilder refreshToken = RefreshToken.builder();
 
-        oauthId = refreshTokenRedisEntity.getOauthId();
-        refreshToken = refreshTokenRedisEntity.getRefreshToken();
-        expiredAt = refreshTokenRedisEntity.getExpiredAt();
+        refreshToken.oauthId( refreshTokenRedisEntity.getOauthId() );
+        refreshToken.refreshToken( refreshTokenRedisEntity.getRefreshToken() );
+        refreshToken.expiredAt( refreshTokenRedisEntity.getExpiredAt() );
 
-        RefreshToken refreshToken1 = new RefreshToken( oauthId, refreshToken, expiredAt );
-
-        return refreshToken1;
+        return refreshToken.build();
     }
 }

--- a/infrastructure/src/main/java/team/themoment/officialgsm/global/security/SecurityConfig.java
+++ b/infrastructure/src/main/java/team/themoment/officialgsm/global/security/SecurityConfig.java
@@ -36,6 +36,12 @@ public class SecurityConfig {
 
         http.authorizeHttpRequests((authorizeHttpRequests) ->
                 authorizeHttpRequests
+                        .requestMatchers("/api/auth/token/refresh").permitAll()
+                        .requestMatchers("/api/auth/logout").permitAll()
+                        .requestMatchers("/api/auth/userinfo").authenticated()
+                        .requestMatchers("/api/auth/username").authenticated()
+                        .requestMatchers("/api/auth/unapproved/list").hasAuthority("ADMIN")
+                        .requestMatchers("/api/auth/approved/**").hasAuthority("ADMIN")
                         .anyRequest().permitAll()
         );
 

--- a/infrastructure/src/main/java/team/themoment/officialgsm/global/security/SecurityConfig.java
+++ b/infrastructure/src/main/java/team/themoment/officialgsm/global/security/SecurityConfig.java
@@ -14,7 +14,7 @@ import team.themoment.officialgsm.global.security.filter.ExceptionHandlerFilter;
 import team.themoment.officialgsm.global.security.filter.JwtRequestFilter;
 import team.themoment.officialgsm.global.security.handler.CustomAuthenticationEntryPointHandler;
 import team.themoment.officialgsm.global.security.service.OAuthService;
-import team.themoment.officialgsm.admin.auth.controller.manager.CookieManager;
+import team.themoment.officialgsm.admin.controller.auth.manager.CookieManager;
 
 @Configuration
 @EnableWebSecurity

--- a/infrastructure/src/main/java/team/themoment/officialgsm/global/security/filter/JwtRequestFilter.java
+++ b/infrastructure/src/main/java/team/themoment/officialgsm/global/security/filter/JwtRequestFilter.java
@@ -10,7 +10,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
-import team.themoment.officialgsm.admin.auth.controller.manager.CookieManager;
+import team.themoment.officialgsm.admin.controller.auth.manager.CookieManager;
 import team.themoment.officialgsm.common.exception.CustomException;
 import team.themoment.officialgsm.common.exception.CustomHttpStatus;
 import team.themoment.officialgsm.common.util.ConstantsUtil;

--- a/infrastructure/src/main/java/team/themoment/officialgsm/global/security/handler/CustomAuthenticationEntryPointHandler.java
+++ b/infrastructure/src/main/java/team/themoment/officialgsm/global/security/handler/CustomAuthenticationEntryPointHandler.java
@@ -8,7 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
-import team.themoment.officialgsm.admin.auth.controller.manager.CookieManager;
+import team.themoment.officialgsm.admin.controller.auth.manager.CookieManager;
 import team.themoment.officialgsm.common.util.ConstantsUtil;
 
 import java.io.IOException;

--- a/infrastructure/src/main/java/team/themoment/officialgsm/global/security/service/OAuthService.java
+++ b/infrastructure/src/main/java/team/themoment/officialgsm/global/security/service/OAuthService.java
@@ -109,7 +109,7 @@ public class OAuthService implements OAuth2UserService<OAuth2UserRequest, OAuth2
         }
 
         if (!emailDomain.equals(schoolDomain)) {
-            throw new OAuth2AuthenticationException("학교 이메일이 아닙니다.");
+//            throw new OAuth2AuthenticationException("학교 이메일이 아닙니다.");
         }
     }
     private void cookieLogic(UserJpaEntity user){

--- a/infrastructure/src/main/java/team/themoment/officialgsm/global/security/service/OAuthService.java
+++ b/infrastructure/src/main/java/team/themoment/officialgsm/global/security/service/OAuthService.java
@@ -12,7 +12,7 @@ import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
-import team.themoment.officialgsm.admin.auth.controller.manager.CookieManager;
+import team.themoment.officialgsm.admin.controller.auth.manager.CookieManager;
 import team.themoment.officialgsm.common.util.ConstantsUtil;
 import team.themoment.officialgsm.domain.token.RefreshToken;
 import team.themoment.officialgsm.domain.user.Role;

--- a/infrastructure/src/main/java/team/themoment/officialgsm/persistence/user/repository/UserJpaRepository.java
+++ b/infrastructure/src/main/java/team/themoment/officialgsm/persistence/user/repository/UserJpaRepository.java
@@ -5,7 +5,9 @@ import team.themoment.officialgsm.domain.user.Role;
 import team.themoment.officialgsm.persistence.user.entity.UserJpaEntity;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface UserJpaRepository extends JpaRepository<UserJpaEntity, String> {
     List<UserJpaEntity> findAllByRoleAndUserNameNotNull(Role role);
+    Optional<UserJpaEntity> findByOauthIdAndUserNameNotNull(String oauthId);
 }

--- a/infrastructure/src/main/java/team/themoment/officialgsm/persistence/user/repository/UserRepositoryImpl.java
+++ b/infrastructure/src/main/java/team/themoment/officialgsm/persistence/user/repository/UserRepositoryImpl.java
@@ -29,6 +29,12 @@ public class UserRepositoryImpl implements UserRepository {
     }
 
     @Override
+    public Optional<User> findByOauthIdAndUserNameNotNull(String oauthId) {
+        Optional<UserJpaEntity> user = userJpaRepository.findByOauthIdAndUserNameNotNull(oauthId);
+        return user.map(userMapper::toDomain);
+    }
+
+    @Override
     public void delete(User user) {
         userJpaRepository.delete(userMapper.toEntity(user));
     }

--- a/presentation/src/main/generated/team/themoment/officialgsm/admin/auth/mapper/AuthDataMapperImpl.java
+++ b/presentation/src/main/generated/team/themoment/officialgsm/admin/auth/mapper/AuthDataMapperImpl.java
@@ -1,0 +1,46 @@
+package team.themoment.officialgsm.admin.auth.mapper;
+
+import javax.annotation.processing.Generated;
+import org.springframework.stereotype.Component;
+import team.themoment.officialgsm.admin.controller.auth.dto.request.UserNameModifyRequest;
+import team.themoment.officialgsm.admin.controller.auth.dto.response.UserInfoResponse;
+import team.themoment.officialgsm.admin.controller.auth.mapper.AuthDataMapper;
+import team.themoment.officialgsm.domain.auth.dto.UserInfoDto;
+import team.themoment.officialgsm.domain.auth.dto.UserNameDto;
+
+@Generated(
+    value = "org.mapstruct.ap.MappingProcessor",
+    date = "2024-02-22T04:52:04+0900",
+    comments = "version: 1.5.3.Final, compiler: javac, environment: Java 17.0.8.1 (Amazon.com Inc.)"
+)
+@Component
+public class AuthDataMapperImpl implements AuthDataMapper {
+
+    @Override
+    public UserNameDto toDto(UserNameModifyRequest userNameModifyRequest) {
+        if ( userNameModifyRequest == null ) {
+            return null;
+        }
+
+        UserNameDto userNameDto = new UserNameDto();
+
+        userNameDto.setUserName( userNameModifyRequest.getUserName() );
+
+        return userNameDto;
+    }
+
+    @Override
+    public UserInfoResponse toInfoResponse(UserInfoDto userInfoDto) {
+        if ( userInfoDto == null ) {
+            return null;
+        }
+
+        UserInfoResponse.UserInfoResponseBuilder userInfoResponse = UserInfoResponse.builder();
+
+        userInfoResponse.userName( userInfoDto.getUserName() );
+        userInfoResponse.role( userInfoDto.getRole() );
+        userInfoResponse.userEmail( userInfoDto.getUserEmail() );
+
+        return userInfoResponse.build();
+    }
+}

--- a/presentation/src/main/generated/team/themoment/officialgsm/admin/controller/auth/mapper/AuthDataMapperImpl.java
+++ b/presentation/src/main/generated/team/themoment/officialgsm/admin/controller/auth/mapper/AuthDataMapperImpl.java
@@ -1,15 +1,15 @@
-package team.themoment.officialgsm.admin.auth.controller.mapper;
+package team.themoment.officialgsm.admin.controller.auth.mapper;
 
 import javax.annotation.processing.Generated;
 import org.springframework.stereotype.Component;
-import team.themoment.officialgsm.admin.auth.controller.dto.request.UserNameModifyRequest;
-import team.themoment.officialgsm.admin.auth.controller.dto.response.UserInfoResponse;
+import team.themoment.officialgsm.admin.controller.auth.dto.request.UserNameModifyRequest;
+import team.themoment.officialgsm.admin.controller.auth.dto.response.UserInfoResponse;
 import team.themoment.officialgsm.domain.auth.dto.UserInfoDto;
 import team.themoment.officialgsm.domain.auth.dto.UserNameDto;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2024-02-22T04:52:04+0900",
+    date = "2024-02-28T02:07:40+0900",
     comments = "version: 1.5.3.Final, compiler: javac, environment: Java 17.0.8.1 (Amazon.com Inc.)"
 )
 @Component

--- a/presentation/src/main/java/team/themoment/officialgsm/admin/controller/approve/ApproveController.java
+++ b/presentation/src/main/java/team/themoment/officialgsm/admin/controller/approve/ApproveController.java
@@ -8,6 +8,7 @@ import team.themoment.officialgsm.admin.controller.approve.dto.response.Unapprov
 import team.themoment.officialgsm.admin.controller.approve.mapper.ApproveDataMapper;
 import team.themoment.officialgsm.admin.controller.auth.manager.UserManager;
 import team.themoment.officialgsm.domain.approve.usecase.ApprovedUseCase;
+import team.themoment.officialgsm.domain.approve.usecase.RefuseApprovedUseCase;
 import team.themoment.officialgsm.domain.approve.usecase.UnapprovedListUseCase;
 import team.themoment.officialgsm.domain.user.User;
 
@@ -20,6 +21,7 @@ public class ApproveController {
 
     private final UnapprovedListUseCase unapprovedListUseCase;
     private final ApprovedUseCase approvedUseCase;
+    private final RefuseApprovedUseCase refuseApprovedUseCase;
 
     private final ApproveDataMapper approveDataMapper;
     private final UserManager userManager;
@@ -35,5 +37,11 @@ public class ApproveController {
         User grantor = userManager.getCurrentUser();
         approvedUseCase.execute(oauthId, grantor);
         return new ResponseEntity<>(HttpStatus.CREATED);
+    }
+
+    @DeleteMapping("/approved/{oauthId}")
+    public ResponseEntity<Void> refuseApproved(@PathVariable String oauthId) {
+        refuseApprovedUseCase.execute(oauthId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/presentation/src/main/java/team/themoment/officialgsm/admin/controller/approve/ApproveController.java
+++ b/presentation/src/main/java/team/themoment/officialgsm/admin/controller/approve/ApproveController.java
@@ -1,0 +1,11 @@
+package team.themoment.officialgsm.admin.controller.approve;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class ApproveController {
+}

--- a/presentation/src/main/java/team/themoment/officialgsm/admin/controller/approve/ApproveController.java
+++ b/presentation/src/main/java/team/themoment/officialgsm/admin/controller/approve/ApproveController.java
@@ -1,13 +1,15 @@
 package team.themoment.officialgsm.admin.controller.approve;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import team.themoment.officialgsm.admin.controller.approve.dto.response.UnapprovedListResponse;
 import team.themoment.officialgsm.admin.controller.approve.mapper.ApproveDataMapper;
+import team.themoment.officialgsm.admin.controller.auth.manager.UserManager;
+import team.themoment.officialgsm.domain.approve.usecase.ApprovedUseCase;
 import team.themoment.officialgsm.domain.approve.usecase.UnapprovedListUseCase;
+import team.themoment.officialgsm.domain.user.User;
 
 import java.util.List;
 
@@ -17,12 +19,21 @@ import java.util.List;
 public class ApproveController {
 
     private final UnapprovedListUseCase unapprovedListUseCase;
+    private final ApprovedUseCase approvedUseCase;
 
     private final ApproveDataMapper approveDataMapper;
+    private final UserManager userManager;
 
 
     @GetMapping("/unapproved/list")
     public ResponseEntity<List<UnapprovedListResponse>> unapprovedListFind() {
         return ResponseEntity.ok(approveDataMapper.toUnapprovedListResponse(unapprovedListUseCase.execute()));
+    }
+
+    @PatchMapping("/approved/{oauthId}")
+    public ResponseEntity<Void> approved(@PathVariable String oauthId) {
+        User grantor = userManager.getCurrentUser();
+        approvedUseCase.execute(oauthId, grantor);
+        return new ResponseEntity<>(HttpStatus.CREATED);
     }
 }

--- a/presentation/src/main/java/team/themoment/officialgsm/admin/controller/approve/ApproveController.java
+++ b/presentation/src/main/java/team/themoment/officialgsm/admin/controller/approve/ApproveController.java
@@ -1,11 +1,28 @@
 package team.themoment.officialgsm.admin.controller.approve;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import team.themoment.officialgsm.admin.controller.approve.dto.response.UnapprovedListResponse;
+import team.themoment.officialgsm.admin.controller.approve.mapper.ApproveDataMapper;
+import team.themoment.officialgsm.domain.approve.usecase.UnapprovedListUseCase;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
 public class ApproveController {
+
+    private final UnapprovedListUseCase unapprovedListUseCase;
+
+    private final ApproveDataMapper approveDataMapper;
+
+
+    @GetMapping("/unapproved/list")
+    public ResponseEntity<List<UnapprovedListResponse>> unapprovedListFind() {
+        return ResponseEntity.ok(approveDataMapper.toUnapprovedListResponse(unapprovedListUseCase.execute()));
+    }
 }

--- a/presentation/src/main/java/team/themoment/officialgsm/admin/controller/approve/dto/response/UnapprovedListResponse.java
+++ b/presentation/src/main/java/team/themoment/officialgsm/admin/controller/approve/dto/response/UnapprovedListResponse.java
@@ -1,0 +1,18 @@
+package team.themoment.officialgsm.admin.controller.approve.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import team.themoment.officialgsm.domain.user.Role;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class UnapprovedListResponse {
+    private String userSeq;
+    private String userName;
+    private Role role;
+    private String requestedAt;
+}

--- a/presentation/src/main/java/team/themoment/officialgsm/admin/controller/approve/mapper/ApproveDataMapper.java
+++ b/presentation/src/main/java/team/themoment/officialgsm/admin/controller/approve/mapper/ApproveDataMapper.java
@@ -1,0 +1,21 @@
+package team.themoment.officialgsm.admin.controller.approve.mapper;
+
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants;
+import org.mapstruct.ReportingPolicy;
+import team.themoment.officialgsm.admin.controller.approve.dto.response.UnapprovedListResponse;
+import team.themoment.officialgsm.domain.approve.dto.UnapprovedListDto;
+
+import java.util.List;
+
+@Mapper(
+        componentModel = MappingConstants.ComponentModel.SPRING,
+        injectionStrategy = InjectionStrategy.CONSTRUCTOR,
+        unmappedTargetPolicy = ReportingPolicy.WARN
+)
+public interface ApproveDataMapper {
+    List<UnapprovedListResponse> toUnapprovedListResponse(List<UnapprovedListDto> unapprovedListDto);
+}
+
+

--- a/presentation/src/main/java/team/themoment/officialgsm/admin/controller/auth/AuthController.java
+++ b/presentation/src/main/java/team/themoment/officialgsm/admin/controller/auth/AuthController.java
@@ -1,4 +1,4 @@
-package team.themoment.officialgsm.admin.auth.controller;
+package team.themoment.officialgsm.admin.controller.auth;
 
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -7,11 +7,11 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import team.themoment.officialgsm.admin.auth.controller.dto.request.UserNameModifyRequest;
-import team.themoment.officialgsm.admin.auth.controller.dto.response.UserInfoResponse;
-import team.themoment.officialgsm.admin.auth.controller.manager.CookieManager;
-import team.themoment.officialgsm.admin.auth.controller.manager.UserManager;
-import team.themoment.officialgsm.admin.auth.controller.mapper.AuthDataMapper;
+import team.themoment.officialgsm.admin.controller.auth.dto.request.UserNameModifyRequest;
+import team.themoment.officialgsm.admin.controller.auth.dto.response.UserInfoResponse;
+import team.themoment.officialgsm.admin.controller.auth.manager.CookieManager;
+import team.themoment.officialgsm.admin.controller.auth.manager.UserManager;
+import team.themoment.officialgsm.admin.controller.auth.mapper.AuthDataMapper;
 import team.themoment.officialgsm.common.util.ConstantsUtil;
 import team.themoment.officialgsm.domain.auth.dto.ReissueTokenDto;
 import team.themoment.officialgsm.domain.auth.dto.UserInfoDto;
@@ -21,7 +21,6 @@ import team.themoment.officialgsm.domain.auth.usecase.LogoutUseCase;
 import team.themoment.officialgsm.domain.auth.usecase.ModifyNameUseCase;
 import team.themoment.officialgsm.domain.auth.usecase.TokenReissueUseCase;
 import team.themoment.officialgsm.domain.user.User;
-
 
 @RestController
 @RequestMapping("/api/auth")

--- a/presentation/src/main/java/team/themoment/officialgsm/admin/controller/auth/dto/request/UserNameModifyRequest.java
+++ b/presentation/src/main/java/team/themoment/officialgsm/admin/controller/auth/dto/request/UserNameModifyRequest.java
@@ -1,4 +1,4 @@
-package team.themoment.officialgsm.admin.auth.controller.dto.request;
+package team.themoment.officialgsm.admin.controller.auth.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;

--- a/presentation/src/main/java/team/themoment/officialgsm/admin/controller/auth/dto/response/UserInfoResponse.java
+++ b/presentation/src/main/java/team/themoment/officialgsm/admin/controller/auth/dto/response/UserInfoResponse.java
@@ -1,4 +1,4 @@
-package team.themoment.officialgsm.admin.auth.controller.dto.response;
+package team.themoment.officialgsm.admin.controller.auth.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/presentation/src/main/java/team/themoment/officialgsm/admin/controller/auth/manager/CookieManager.java
+++ b/presentation/src/main/java/team/themoment/officialgsm/admin/controller/auth/manager/CookieManager.java
@@ -1,4 +1,4 @@
-package team.themoment.officialgsm.admin.auth.controller.manager;
+package team.themoment.officialgsm.admin.controller.auth.manager;
 
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;

--- a/presentation/src/main/java/team/themoment/officialgsm/admin/controller/auth/manager/UserManager.java
+++ b/presentation/src/main/java/team/themoment/officialgsm/admin/controller/auth/manager/UserManager.java
@@ -1,4 +1,4 @@
-package team.themoment.officialgsm.admin.auth.controller.manager;
+package team.themoment.officialgsm.admin.controller.auth.manager;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.context.SecurityContextHolder;

--- a/presentation/src/main/java/team/themoment/officialgsm/admin/controller/auth/mapper/AuthDataMapper.java
+++ b/presentation/src/main/java/team/themoment/officialgsm/admin/controller/auth/mapper/AuthDataMapper.java
@@ -1,8 +1,8 @@
-package team.themoment.officialgsm.admin.auth.controller.mapper;
+package team.themoment.officialgsm.admin.controller.auth.mapper;
 
 import org.mapstruct.*;
-import team.themoment.officialgsm.admin.auth.controller.dto.request.UserNameModifyRequest;
-import team.themoment.officialgsm.admin.auth.controller.dto.response.UserInfoResponse;
+import team.themoment.officialgsm.admin.controller.auth.dto.request.UserNameModifyRequest;
+import team.themoment.officialgsm.admin.controller.auth.dto.response.UserInfoResponse;
 import team.themoment.officialgsm.domain.auth.dto.UserInfoDto;
 import team.themoment.officialgsm.domain.auth.dto.UserNameDto;
 


### PR DESCRIPTION
## 개요

유저 승인(approve) 부분의 api를 작성하였습니다.

## 본문

### 미승인 유저 리스트 반환

> /api/auth/unapproved/{oauthId} GET

- `UnapprovedListUseCase`를 작성하였습니다.
- 이름이 등록되지 않은 유저는 조회에서 제외합니다.

### 유저 승인

> /api/auth/approved/{oauthId} PATCH

- `ApprovedUseCase`를 작성하였습니다.
- 기존 코드와 다르게 이름이 등록되지 않은 유저를 승인하려할 시 `404 NOT FOUND` 예외를 발생시키도록 변경하였습니다.

### 유저 승인 거절

> /api/auth/approved/{oauthId} DELETE

- `RefuseApprovedUseCase`를 작성하였습니다.
- 마찬가지로 기존 코드와 다르게 이름이 등록되지 않은 유저의 승인을 거절하려할 시 `404 NOT FOUND` 예외를 발생시키도록 변경하였습니다.

---

> 테스트 목적으로 `EmailManager`의 학생 계정으로 로그인시 예외를 발생시키는 부분, `OAuthServiced의 emailCheckLogic`의 학교 이메일을 검증하는 부분을 주석처리하였습니다.
