### PR TITLE
feature/authTestCode

### DIFF
--- a/application/src/test/java/team/themoment/officialgsm/domain/auth/usecase/FindUserInfoUseCaseTest.java
+++ b/application/src/test/java/team/themoment/officialgsm/domain/auth/usecase/FindUserInfoUseCaseTest.java
@@ -1,0 +1,32 @@
+package team.themoment.officialgsm.domain.auth.usecase;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.themoment.officialgsm.domain.auth.dto.UserInfoDto;
+import team.themoment.officialgsm.domain.user.Role;
+import team.themoment.officialgsm.domain.user.User;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class FindUserInfoUseCaseTest {
+
+    @InjectMocks
+    private FindUserInfoUseCase findUserInfoUseCase;
+
+    @Test
+    void execute() {
+        // given
+        User user = new User("0", "신희성", "s23012@gsm.hs.kr", Role.ADMIN, null, null, null);
+
+        // when
+        UserInfoDto result = findUserInfoUseCase.execute(user);
+
+        // then
+        assertThat("신희성").isEqualTo(result.getUserName());
+        assertThat("s23012@gsm.hs.kr").isEqualTo(result.getUserEmail());
+        assertThat(Role.ADMIN).isEqualTo(result.getRole());
+    }
+}

--- a/application/src/test/java/team/themoment/officialgsm/domain/auth/usecase/LogoutUseCaseTest.java
+++ b/application/src/test/java/team/themoment/officialgsm/domain/auth/usecase/LogoutUseCaseTest.java
@@ -75,4 +75,28 @@ class LogoutUseCaseTest {
         verify(refreshTokenRepository, never()).delete(any());
         verify(blackListRepository, never()).save(any());
     }
+
+    @Test
+    void execute_blackListConflict() {
+        // given
+        String accessTokenValue = "0";
+        String refreshTokenValue = "0";
+        String oauthId = "0";
+
+        User user = new User(oauthId, "신희성", "s23012@gsm.hs.kr", Role.UNAPPROVED, null, null, null);
+        RefreshToken refreshToken = new RefreshToken(oauthId, refreshTokenValue, 7200L);
+
+        given(refreshTokenRepository.findByOauthId(oauthId)).willReturn(Optional.of(refreshToken));
+
+        ValueOperations<String, String> valueOperationsMock = mock(ValueOperations.class);
+        given(redisTemplate.opsForValue()).willReturn(valueOperationsMock);
+        given(valueOperationsMock.get(accessTokenValue)).willReturn("0");
+
+        // when
+        assertThrows(CustomException.class, () -> logoutUseCase.execute(accessTokenValue, user));
+
+        // then
+        verify(refreshTokenRepository, never()).save(any());
+        verify(blackListRepository, never()).save(any());
+    }
 }

--- a/application/src/test/java/team/themoment/officialgsm/domain/auth/usecase/LogoutUseCaseTest.java
+++ b/application/src/test/java/team/themoment/officialgsm/domain/auth/usecase/LogoutUseCaseTest.java
@@ -7,6 +7,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
+import team.themoment.officialgsm.common.exception.CustomException;
 import team.themoment.officialgsm.domain.token.BlackList;
 import team.themoment.officialgsm.domain.token.RefreshToken;
 import team.themoment.officialgsm.domain.user.Role;
@@ -16,6 +17,7 @@ import team.themoment.officialgsm.repository.token.RefreshTokenRepository;
 
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
@@ -54,5 +56,23 @@ class LogoutUseCaseTest {
         // then
         verify(refreshTokenRepository, times(1)).delete(refreshToken);
         verify(blackListRepository, times(1)).save(new BlackList(oauthId, accessTokenValue, 7200L));
+    }
+
+    @Test
+    void execute_refreshTokenNotFound() {
+        // given
+        String accessTokenValue = "0";
+        String oauthId = "0";
+
+        User user = new User(oauthId, "신희성", "s23012@gsm.hs.kr", Role.UNAPPROVED, null, null, null);
+
+        given(refreshTokenRepository.findByOauthId(oauthId)).willReturn(Optional.empty());
+
+        // when
+        assertThrows(CustomException.class, () -> logoutUseCase.execute(accessTokenValue, user));
+
+        // then
+        verify(refreshTokenRepository, never()).delete(any());
+        verify(blackListRepository, never()).save(any());
     }
 }

--- a/application/src/test/java/team/themoment/officialgsm/domain/auth/usecase/LogoutUseCaseTest.java
+++ b/application/src/test/java/team/themoment/officialgsm/domain/auth/usecase/LogoutUseCaseTest.java
@@ -1,0 +1,58 @@
+package team.themoment.officialgsm.domain.auth.usecase;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import team.themoment.officialgsm.domain.token.BlackList;
+import team.themoment.officialgsm.domain.token.RefreshToken;
+import team.themoment.officialgsm.domain.user.Role;
+import team.themoment.officialgsm.domain.user.User;
+import team.themoment.officialgsm.repository.token.BlackListRepository;
+import team.themoment.officialgsm.repository.token.RefreshTokenRepository;
+
+import java.util.Optional;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class LogoutUseCaseTest {
+
+    @InjectMocks
+    private LogoutUseCase logoutUseCase;
+
+    @Mock
+    private BlackListRepository blackListRepository;
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Mock
+    private RedisTemplate redisTemplate;
+
+    @Test
+    void execute() {
+        // given
+        String accessTokenValue = "0";
+        String refreshTokenValue = "0";
+        String oauthId = "0";
+
+        User user = new User(oauthId, "신희성", "s23012@gsm.hs.kr", Role.UNAPPROVED, null, null, null);
+        RefreshToken refreshToken = new RefreshToken(oauthId, refreshTokenValue, 7200L);
+
+        given(refreshTokenRepository.findByOauthId(oauthId)).willReturn(Optional.of(refreshToken));
+
+        given(redisTemplate.opsForValue()).willReturn(mock(ValueOperations.class));
+
+        // when
+        logoutUseCase.execute(accessTokenValue, user);
+
+        // then
+        verify(refreshTokenRepository, times(1)).delete(refreshToken);
+        verify(blackListRepository, times(1)).save(new BlackList(oauthId, accessTokenValue, 7200L));
+    }
+}

--- a/application/src/test/java/team/themoment/officialgsm/domain/auth/usecase/ModifyNameUseCaseTest.java
+++ b/application/src/test/java/team/themoment/officialgsm/domain/auth/usecase/ModifyNameUseCaseTest.java
@@ -1,0 +1,38 @@
+package team.themoment.officialgsm.domain.auth.usecase;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.themoment.officialgsm.domain.auth.dto.UserNameDto;
+import team.themoment.officialgsm.domain.user.Role;
+import team.themoment.officialgsm.domain.user.User;
+import team.themoment.officialgsm.repository.user.UserRepository;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ModifyNameUseCaseTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private ModifyNameUseCase modifyNameUseCase;
+
+    @Test
+    void execute() {
+        // given
+        UserNameDto dto = new UserNameDto("신희성");
+        User currentUser = new User("0", null, "s23012@gsm.hs.kr", Role.UNAPPROVED, null, null, null);
+        User modifiedUser = new User("0", "신희성", "s23012@gsm.hs.kr", Role.UNAPPROVED, null, null, null);
+
+        // when
+        modifyNameUseCase.execute(dto, currentUser);
+
+        // then
+        verify(userRepository, times(1)).save(modifiedUser);
+    }
+}

--- a/application/src/test/java/team/themoment/officialgsm/domain/auth/usecase/TokenReissueUseCaseTest.java
+++ b/application/src/test/java/team/themoment/officialgsm/domain/auth/usecase/TokenReissueUseCaseTest.java
@@ -1,0 +1,67 @@
+package team.themoment.officialgsm.domain.auth.usecase;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.themoment.officialgsm.domain.auth.dto.ReissueTokenDto;
+import team.themoment.officialgsm.domain.auth.spi.TokenProvider;
+import team.themoment.officialgsm.domain.token.RefreshToken;
+import team.themoment.officialgsm.domain.user.Role;
+import team.themoment.officialgsm.domain.user.User;
+import team.themoment.officialgsm.repository.token.RefreshTokenRepository;
+import team.themoment.officialgsm.repository.user.UserRepository;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+
+@ExtendWith(MockitoExtension.class)
+class TokenReissueUseCaseTest {
+
+    @InjectMocks
+    private TokenReissueUseCase tokenReissueUseCase;
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private TokenProvider tokenProvider;
+
+    @Test
+    void execute() {
+        // given
+        String refreshTokenValue = "0";
+        String oauthId = "0";
+        String refreshSecret = "0";
+
+        User user = new User(oauthId, "신희성", "s23012@gsm.hs.kr", Role.UNAPPROVED, null, null, null);
+        RefreshToken refreshToken = new RefreshToken(oauthId, refreshTokenValue, 0L);
+
+        given(tokenProvider.getRefreshSecert()).willReturn(refreshSecret);
+        given(tokenProvider.getRefreshTokenOauthId(refreshTokenValue, refreshSecret)).willReturn(oauthId);
+
+        given(userRepository.findByOauthId(oauthId)).willReturn(Optional.of(user));
+        given(refreshTokenRepository.findByOauthId(oauthId)).willReturn(Optional.of(refreshToken));
+
+        given(tokenProvider.generatedAccessToken(oauthId)).willReturn("1");
+        given(tokenProvider.generatedRefreshToken(oauthId)).willReturn("1");
+
+        // when
+        ReissueTokenDto reissueTokenDto = tokenReissueUseCase.execute(refreshTokenValue);
+
+        // then
+        verify(refreshTokenRepository, times(1)).save(refreshToken.updateRefreshToken("1"));
+
+        assertThat(reissueTokenDto.getAccessToken()).isEqualTo("1");
+        assertThat(reissueTokenDto.getRefreshToken()).isEqualTo("1");
+    }
+}

--- a/application/src/test/java/team/themoment/officialgsm/domain/auth/usecase/TokenReissueUseCaseTest.java
+++ b/application/src/test/java/team/themoment/officialgsm/domain/auth/usecase/TokenReissueUseCaseTest.java
@@ -77,4 +77,25 @@ class TokenReissueUseCaseTest {
         verify(userRepository, never()).findByOauthId(any());
         verify(refreshTokenRepository, never()).save(any());
     }
+
+    @Test
+    void execute_userNotFound() {
+        // given
+        String refreshTokenValue = "0";
+        String oauthId = "0";
+        String refreshSecret = "0";
+
+        given(tokenProvider.getRefreshSecert()).willReturn(refreshSecret);
+        given(tokenProvider.getRefreshTokenOauthId(refreshTokenValue, refreshSecret)).willReturn(oauthId);
+
+        given(userRepository.findByOauthId(oauthId)).willReturn(Optional.empty());
+
+        // when
+        assertThrows(CustomException.class, () -> tokenReissueUseCase.execute(refreshTokenValue));
+
+        // then
+        verify(refreshTokenRepository, never()).findByOauthId(any());
+
+        verify(refreshTokenRepository, never()).save(any());
+    }
 }

--- a/application/src/test/java/team/themoment/officialgsm/domain/auth/usecase/TokenReissueUseCaseTest.java
+++ b/application/src/test/java/team/themoment/officialgsm/domain/auth/usecase/TokenReissueUseCaseTest.java
@@ -1,11 +1,11 @@
 package team.themoment.officialgsm.domain.auth.usecase;
 
-import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import team.themoment.officialgsm.common.exception.CustomException;
 import team.themoment.officialgsm.domain.auth.dto.ReissueTokenDto;
 import team.themoment.officialgsm.domain.auth.spi.TokenProvider;
 import team.themoment.officialgsm.domain.token.RefreshToken;
@@ -17,8 +17,11 @@ import team.themoment.officialgsm.repository.user.UserRepository;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.never;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -63,5 +66,15 @@ class TokenReissueUseCaseTest {
 
         assertThat(reissueTokenDto.getAccessToken()).isEqualTo("1");
         assertThat(reissueTokenDto.getRefreshToken()).isEqualTo("1");
+    }
+
+    @Test
+    void execute_refreshTokenIsNull() {
+        // given &  when
+        assertThrows(CustomException.class, () -> tokenReissueUseCase.execute(null));
+
+        // then
+        verify(userRepository, never()).findByOauthId(any());
+        verify(refreshTokenRepository, never()).save(any());
     }
 }

--- a/application/src/test/java/team/themoment/officialgsm/domain/auth/usecase/TokenReissueUseCaseTest.java
+++ b/application/src/test/java/team/themoment/officialgsm/domain/auth/usecase/TokenReissueUseCaseTest.java
@@ -98,4 +98,27 @@ class TokenReissueUseCaseTest {
 
         verify(refreshTokenRepository, never()).save(any());
     }
+
+    @Test
+    void execute_refreshTokenIsNotValid() {
+        // given
+        String refreshTokenValue = "0";
+        String oauthId = "0";
+        String refreshSecret = "0";
+
+        User user = new User(oauthId, "신희성", "s23012@gsm.hs.kr", Role.UNAPPROVED, null, null, null);
+        RefreshToken refreshToken = new RefreshToken(oauthId, refreshTokenValue + 1, 0L);
+
+        given(tokenProvider.getRefreshSecert()).willReturn(refreshSecret);
+        given(tokenProvider.getRefreshTokenOauthId(refreshTokenValue, refreshSecret)).willReturn(oauthId);
+
+        given(userRepository.findByOauthId(oauthId)).willReturn(Optional.of(user));
+        given(refreshTokenRepository.findByOauthId(oauthId)).willReturn(Optional.of(refreshToken));
+
+        // when
+        assertThrows(CustomException.class, () -> tokenReissueUseCase.execute(refreshTokenValue));
+
+        // then
+        verify(refreshTokenRepository, never()).save(any());
+    }
 }

--- a/presentation/src/test/java/team/themoment/officialgsm/admin/controller/auth/AuthControllerTest.java
+++ b/presentation/src/test/java/team/themoment/officialgsm/admin/controller/auth/AuthControllerTest.java
@@ -1,0 +1,23 @@
+package team.themoment.officialgsm.admin.controller.auth;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@ExtendWith(MockitoExtension.class)
+class AuthControllerTest {
+
+    @InjectMocks
+    AuthController authController;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    public void init() {
+        mockMvc = MockMvcBuilders.standaloneSetup(authController)
+                .build();
+    }
+}

--- a/presentation/src/test/java/team/themoment/officialgsm/admin/controller/auth/AuthControllerTest.java
+++ b/presentation/src/test/java/team/themoment/officialgsm/admin/controller/auth/AuthControllerTest.java
@@ -1,11 +1,27 @@
 package team.themoment.officialgsm.admin.controller.auth;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import team.themoment.officialgsm.admin.controller.auth.dto.request.UserNameModifyRequest;
+import team.themoment.officialgsm.admin.controller.auth.manager.UserManager;
+import team.themoment.officialgsm.admin.controller.auth.mapper.AuthDataMapper;
+import team.themoment.officialgsm.domain.auth.usecase.ModifyNameUseCase;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)
 class AuthControllerTest {
@@ -13,11 +29,37 @@ class AuthControllerTest {
     @InjectMocks
     AuthController authController;
 
+    @Mock
+    ModifyNameUseCase modifyNameUseCase;
+
+    @Mock
+    UserManager userManager;
+
+    @Mock
+    AuthDataMapper userDataMapper;
+
     private MockMvc mockMvc;
 
     @BeforeEach
     public void init() {
         mockMvc = MockMvcBuilders.standaloneSetup(authController)
                 .build();
+    }
+
+    @Test
+    void nameModify() throws Exception {
+        // given
+        UserNameModifyRequest request = new UserNameModifyRequest("신희성");
+
+        // when
+        ResultActions resultActions = mockMvc.perform(patch("/api/auth/username")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(new ObjectMapper().writeValueAsString(request)));
+
+
+        // then
+        resultActions.andExpect(status().isOk());
+
+        verify(modifyNameUseCase, times(1)).execute(eq(userDataMapper.toDto(request)), any());
     }
 }

--- a/presentation/src/test/java/team/themoment/officialgsm/admin/controller/auth/AuthControllerTest.java
+++ b/presentation/src/test/java/team/themoment/officialgsm/admin/controller/auth/AuthControllerTest.java
@@ -17,10 +17,13 @@ import team.themoment.officialgsm.admin.controller.auth.manager.CookieManager;
 import team.themoment.officialgsm.admin.controller.auth.manager.UserManager;
 import team.themoment.officialgsm.admin.controller.auth.mapper.AuthDataMapper;
 import team.themoment.officialgsm.common.util.ConstantsUtil;
+import team.themoment.officialgsm.domain.auth.dto.ReissueTokenDto;
 import team.themoment.officialgsm.domain.auth.dto.UserInfoDto;
+import team.themoment.officialgsm.domain.auth.spi.TokenProvider;
 import team.themoment.officialgsm.domain.auth.usecase.FindUserInfoUseCase;
 import team.themoment.officialgsm.domain.auth.usecase.LogoutUseCase;
 import team.themoment.officialgsm.domain.auth.usecase.ModifyNameUseCase;
+import team.themoment.officialgsm.domain.auth.usecase.TokenReissueUseCase;
 import team.themoment.officialgsm.domain.user.Role;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -46,6 +49,12 @@ class AuthControllerTest {
 
     @Mock
     LogoutUseCase logoutUseCase;
+
+    @Mock
+    TokenReissueUseCase tokenReissueUseCase;
+
+    @Mock
+    TokenProvider tokenProvider;
 
     @Mock
     CookieManager cookieManager;
@@ -119,5 +128,24 @@ class AuthControllerTest {
         resultActions.andExpect(status().isNoContent());
 
         verify(logoutUseCase, times(1)).execute(eq(accessToken), any());
+    }
+
+    @Test
+    void tokenReissue() throws Exception {
+        // given
+        String token = "0";
+
+        ReissueTokenDto reissueTokenDto = new ReissueTokenDto("0", "0");
+
+        given(cookieManager.getCookieValue(any(), eq(ConstantsUtil.refreshToken))).willReturn(token);
+        given(tokenReissueUseCase.execute(eq(token))).willReturn(reissueTokenDto);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(get("/api/auth/token/refresh"));
+
+        // then
+        resultActions.andExpect(status().isOk());
+
+        verify(tokenReissueUseCase, times(1)).execute(eq(token));
     }
 }

--- a/presentation/src/test/java/team/themoment/officialgsm/admin/controller/auth/AuthControllerTest.java
+++ b/presentation/src/test/java/team/themoment/officialgsm/admin/controller/auth/AuthControllerTest.java
@@ -13,10 +13,13 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import team.themoment.officialgsm.admin.controller.auth.dto.request.UserNameModifyRequest;
 import team.themoment.officialgsm.admin.controller.auth.dto.response.UserInfoResponse;
+import team.themoment.officialgsm.admin.controller.auth.manager.CookieManager;
 import team.themoment.officialgsm.admin.controller.auth.manager.UserManager;
 import team.themoment.officialgsm.admin.controller.auth.mapper.AuthDataMapper;
+import team.themoment.officialgsm.common.util.ConstantsUtil;
 import team.themoment.officialgsm.domain.auth.dto.UserInfoDto;
 import team.themoment.officialgsm.domain.auth.usecase.FindUserInfoUseCase;
+import team.themoment.officialgsm.domain.auth.usecase.LogoutUseCase;
 import team.themoment.officialgsm.domain.auth.usecase.ModifyNameUseCase;
 import team.themoment.officialgsm.domain.user.Role;
 
@@ -25,8 +28,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -41,6 +43,12 @@ class AuthControllerTest {
 
     @Mock
     FindUserInfoUseCase findUserInfoUseCase;
+
+    @Mock
+    LogoutUseCase logoutUseCase;
+
+    @Mock
+    CookieManager cookieManager;
 
     @Mock
     UserManager userManager;
@@ -94,5 +102,22 @@ class AuthControllerTest {
 
         verify(findUserInfoUseCase, times(1)).execute(any());
         verify(userDataMapper, times(1)).toInfoResponse(mockUserInfoDto);
+    }
+
+
+    @Test
+    void logout() throws Exception {
+        // given
+        String accessToken = "0";
+
+        given(cookieManager.getCookieValue(any(), eq(ConstantsUtil.accessToken))).willReturn(accessToken);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(delete("/api/auth/logout"));
+
+        // then
+        resultActions.andExpect(status().isNoContent());
+
+        verify(logoutUseCase, times(1)).execute(eq(accessToken), any());
     }
 }

--- a/presentation/src/test/java/team/themoment/officialgsm/admin/controller/auth/AuthControllerTest.java
+++ b/presentation/src/test/java/team/themoment/officialgsm/admin/controller/auth/AuthControllerTest.java
@@ -12,15 +12,22 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import team.themoment.officialgsm.admin.controller.auth.dto.request.UserNameModifyRequest;
+import team.themoment.officialgsm.admin.controller.auth.dto.response.UserInfoResponse;
 import team.themoment.officialgsm.admin.controller.auth.manager.UserManager;
 import team.themoment.officialgsm.admin.controller.auth.mapper.AuthDataMapper;
+import team.themoment.officialgsm.domain.auth.dto.UserInfoDto;
+import team.themoment.officialgsm.domain.auth.usecase.FindUserInfoUseCase;
 import team.themoment.officialgsm.domain.auth.usecase.ModifyNameUseCase;
+import team.themoment.officialgsm.domain.user.Role;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)
@@ -31,6 +38,9 @@ class AuthControllerTest {
 
     @Mock
     ModifyNameUseCase modifyNameUseCase;
+
+    @Mock
+    FindUserInfoUseCase findUserInfoUseCase;
 
     @Mock
     UserManager userManager;
@@ -61,5 +71,28 @@ class AuthControllerTest {
         resultActions.andExpect(status().isOk());
 
         verify(modifyNameUseCase, times(1)).execute(eq(userDataMapper.toDto(request)), any());
+    }
+
+    @Test
+    void userInfoFind() throws Exception {
+        // given
+        UserInfoDto mockUserInfoDto = new UserInfoDto("신희성", Role.ADMIN, "s23012@gsm.hs.kr");
+        UserInfoResponse mockUserInfoResponse = new UserInfoResponse("신희성", Role.ADMIN, "s23012@gsm.hs.kr");
+
+        given(findUserInfoUseCase.execute(any())).willReturn(mockUserInfoDto);
+        given(userDataMapper.toInfoResponse(any(UserInfoDto.class))).willReturn(mockUserInfoResponse);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(get("/api/auth/userinfo"));
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userName").value("신희성"))
+                .andExpect(jsonPath("$.role").value("ADMIN"))
+                .andExpect(jsonPath("$.userEmail").value("s23012@gsm.hs.kr"));
+
+        verify(findUserInfoUseCase, times(1)).execute(any());
+        verify(userDataMapper, times(1)).toInfoResponse(mockUserInfoDto);
     }
 }


### PR DESCRIPTION
## 개요

- Auth 부분의 controller, usecase 테스트코드를 작성하였습니다.
- `feature/approve` 브랜치에서 브랜치를 생성하여서 작업하였습니다.

## 본문

**AuthControllerTest**
- `nameModify`, `userInfoFind`, `logout`, `tokenReissue` controller 테스트코드를 작성하였습니다

**ModifyNameUseCaseTest**
- execute: 이름이 변경된 유저객체가 잘 save되는지 확인합니다.

**FindUserInfoUseCaseTest**
- execute: User객체를 UserInfoDto객체로 매핑하는 역할을 잘 수행하는지 확인합니다.

**LogoutUseCaseTest**
- execute: `refreshToken`의 삭제 메서드가 실행되는지, `blackList`에 유저의 토큰이 저장되는지 확인합니다.
- execute_refreshTokenNotFound: 데이터베이스에 유저의 `refreshToken`가 없을때 예외가 발생하는지 확인합니다.
- execute_blackListConflict: 이미 블랙리스트에 유저의 토큰이 저장되어 있을때 예외가 발생하는지 확인합니다.

**TokenReissueUseCaseTest**
- execute: 유저의 `accessToken`으로 `refreshToken`, `accessToken`을 잘 발급하여 반환하는지 확인합니다.
- execute_refreshTokenIsNull: 실행 파라미터로 `refreshToken`을 넘기지 않았을때(null) 예외가 발생하는지 확인합니다.
- execute_userNotFound: `refreshToken`으로 유저 정보를 디비에서 조회했을 때 유저가 없을시 예외가 발생하는지 확인합니다.
- execute_refreshTokenIsNotValid: `refreshToken`이 유효하지 않을때 예외가 발생하는지 확인합니다.