### PR TITLE
feature/approveTestCode

### DIFF
--- a/application/src/test/java/team/themoment/officialgsm/domain/approve/usecase/ApprovedUseCaseTest.java
+++ b/application/src/test/java/team/themoment/officialgsm/domain/approve/usecase/ApprovedUseCaseTest.java
@@ -1,0 +1,55 @@
+package team.themoment.officialgsm.domain.approve.usecase;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.themoment.officialgsm.domain.user.Role;
+import team.themoment.officialgsm.domain.user.User;
+import team.themoment.officialgsm.repository.user.UserRepository;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ApprovedUseCaseTest {
+
+    @InjectMocks
+    private ApprovedUseCase approvedUseCase;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Captor
+    private ArgumentCaptor<User> userCaptor;
+
+    @Test
+    void execute() {
+        // given
+        String oauthId = "0";
+        User user = new User(oauthId, "신희성", "s23012@gsm.hs.kr", Role.UNAPPROVED, null, null, null);
+        User grantor = new User("1", "최장우", "s22000@gsm.hs.kr", Role.ADMIN, null, null, null);
+
+        given(userRepository.findByOauthId(oauthId)).willReturn(Optional.of(user));
+
+        // when
+        approvedUseCase.execute(oauthId, grantor);
+
+        // then
+        verify(userRepository, times(1)).save(userCaptor.capture());
+
+        User capturedUser = userCaptor.getValue();
+
+        assertNotNull(capturedUser);
+        assertThat(Role.ADMIN).isEqualTo(capturedUser.role());
+        assertThat(user.userName()).isEqualTo(capturedUser.userName());
+        assertThat(grantor).isEqualTo(capturedUser.grantor());
+    }
+}

--- a/application/src/test/java/team/themoment/officialgsm/domain/approve/usecase/ApprovedUseCaseTest.java
+++ b/application/src/test/java/team/themoment/officialgsm/domain/approve/usecase/ApprovedUseCaseTest.java
@@ -7,6 +7,7 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import team.themoment.officialgsm.common.exception.CustomException;
 import team.themoment.officialgsm.domain.user.Role;
 import team.themoment.officialgsm.domain.user.User;
 import team.themoment.officialgsm.repository.user.UserRepository;
@@ -15,9 +16,10 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class ApprovedUseCaseTest {
@@ -52,5 +54,21 @@ class ApprovedUseCaseTest {
         assertThat(Role.ADMIN).isEqualTo(capturedUser.role());
         assertThat(user.userName()).isEqualTo(capturedUser.userName());
         assertThat(grantor).isEqualTo(capturedUser.grantor());
+    }
+
+    @Test
+    void execute_userNotFound() {
+        // given
+        String oauthId = "0";
+        User grantor = new User("1", "최장우", "s22000@gsm.hs.kr", Role.ADMIN, null, null, null);
+
+        given(userRepository.findByOauthIdAndUserNameNotNull(oauthId)).willReturn(Optional.empty());
+
+        // when
+        assertThrows(CustomException.class, () -> approvedUseCase.execute(oauthId, grantor));
+
+        // then
+        verify(userRepository, times(1)).findByOauthIdAndUserNameNotNull(oauthId);
+        verify(userRepository, never()).save(any());
     }
 }

--- a/application/src/test/java/team/themoment/officialgsm/domain/approve/usecase/ApprovedUseCaseTest.java
+++ b/application/src/test/java/team/themoment/officialgsm/domain/approve/usecase/ApprovedUseCaseTest.java
@@ -14,9 +14,10 @@ import team.themoment.officialgsm.repository.user.UserRepository;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class ApprovedUseCaseTest {
@@ -37,7 +38,7 @@ class ApprovedUseCaseTest {
         User user = new User(oauthId, "신희성", "s23012@gsm.hs.kr", Role.UNAPPROVED, null, null, null);
         User grantor = new User("1", "최장우", "s22000@gsm.hs.kr", Role.ADMIN, null, null, null);
 
-        given(userRepository.findByOauthId(oauthId)).willReturn(Optional.of(user));
+        given(userRepository.findByOauthIdAndUserNameNotNull(oauthId)).willReturn(Optional.of(user));
 
         // when
         approvedUseCase.execute(oauthId, grantor);

--- a/application/src/test/java/team/themoment/officialgsm/domain/approve/usecase/RefuseApprovedUseCaseTest.java
+++ b/application/src/test/java/team/themoment/officialgsm/domain/approve/usecase/RefuseApprovedUseCaseTest.java
@@ -1,0 +1,42 @@
+package team.themoment.officialgsm.domain.approve.usecase;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.themoment.officialgsm.domain.user.Role;
+import team.themoment.officialgsm.domain.user.User;
+import team.themoment.officialgsm.repository.user.UserRepository;
+
+import java.util.Optional;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RefuseApprovedUseCaseTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private RefuseApprovedUseCase refuseApprovedUseCase;
+
+    @Test
+    void execute() {
+        // given
+        String oauthId = "0";
+
+        User user = new User(oauthId, "신희성", "s23012@gsm.hs.kr", Role.UNAPPROVED, null, null, null);
+
+        given(userRepository.findByOauthIdAndUserNameNotNull(oauthId)).willReturn(Optional.of(user));
+
+        // when
+        refuseApprovedUseCase.execute(oauthId);
+
+        // then
+        verify(userRepository, times(1)).findByOauthIdAndUserNameNotNull(oauthId);
+        verify(userRepository, times(1)).delete(user);
+    }
+}

--- a/application/src/test/java/team/themoment/officialgsm/domain/approve/usecase/RefuseApprovedUseCaseTest.java
+++ b/application/src/test/java/team/themoment/officialgsm/domain/approve/usecase/RefuseApprovedUseCaseTest.java
@@ -5,12 +5,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import team.themoment.officialgsm.common.exception.CustomException;
 import team.themoment.officialgsm.domain.user.Role;
 import team.themoment.officialgsm.domain.user.User;
 import team.themoment.officialgsm.repository.user.UserRepository;
 
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
@@ -38,5 +40,20 @@ class RefuseApprovedUseCaseTest {
         // then
         verify(userRepository, times(1)).findByOauthIdAndUserNameNotNull(oauthId);
         verify(userRepository, times(1)).delete(user);
+    }
+
+    @Test
+    void execute_userNotFound() {
+        // given
+        String oauthId = "0";
+
+        given(userRepository.findByOauthIdAndUserNameNotNull(oauthId)).willReturn(Optional.empty());
+
+        // when
+        assertThrows(CustomException.class, () -> refuseApprovedUseCase.execute(oauthId));
+
+        // then
+        verify(userRepository, times(1)).findByOauthIdAndUserNameNotNull(oauthId);
+        verify(userRepository, never()).delete(any());
     }
 }

--- a/application/src/test/java/team/themoment/officialgsm/domain/approve/usecase/UnapprovedListUseCaseTest.java
+++ b/application/src/test/java/team/themoment/officialgsm/domain/approve/usecase/UnapprovedListUseCaseTest.java
@@ -1,0 +1,51 @@
+package team.themoment.officialgsm.domain.approve.usecase;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.themoment.officialgsm.domain.approve.dto.UnapprovedListDto;
+import team.themoment.officialgsm.domain.user.Role;
+import team.themoment.officialgsm.domain.user.User;
+import team.themoment.officialgsm.repository.user.UserRepository;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class UnapprovedListUseCaseTest {
+
+    @InjectMocks
+    private UnapprovedListUseCase unapprovedListUseCase;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Test
+    void execute() {
+        // given
+        String oauthId = "0";
+        String userName = "신희성";
+        Role userRole = Role.UNAPPROVED;
+
+        List<User> userList = List.of(new User(oauthId, userName, "s23012@gsm.hs.kr", userRole, null, null, null));
+
+        given(userRepository.findAllByRoleAndUserNameNotNull(userRole)).willReturn(userList);
+
+        // when
+        List<UnapprovedListDto> result = unapprovedListUseCase.execute();
+
+        // then
+        verify(userRepository, times(1)).findAllByRoleAndUserNameNotNull(userRole);
+
+        assertThat(oauthId).isEqualTo(result.get(0).getUserSeq());
+        assertThat(userName).isEqualTo(result.get(0).getUserName());
+        assertThat(userRole).isEqualTo(result.get(0).getRole());
+
+    }
+}

--- a/application/src/test/java/team/themoment/officialgsm/domain/auth/usecase/TokenReissueUseCaseTest.java
+++ b/application/src/test/java/team/themoment/officialgsm/domain/auth/usecase/TokenReissueUseCaseTest.java
@@ -77,4 +77,25 @@ class TokenReissueUseCaseTest {
         verify(userRepository, never()).findByOauthId(any());
         verify(refreshTokenRepository, never()).save(any());
     }
+
+    @Test
+    void execute_userNotFound() {
+        // given
+        String refreshTokenValue = "0";
+        String oauthId = "0";
+        String refreshSecret = "0";
+
+        given(tokenProvider.getRefreshSecert()).willReturn(refreshSecret);
+        given(tokenProvider.getRefreshTokenOauthId(refreshTokenValue, refreshSecret)).willReturn(oauthId);
+
+        given(userRepository.findByOauthId(oauthId)).willReturn(Optional.empty());
+
+        // when
+        assertThrows(CustomException.class, () -> tokenReissueUseCase.execute(refreshTokenValue));
+
+        // then
+        verify(refreshTokenRepository, never()).findByOauthId(any());
+
+        verify(refreshTokenRepository, never()).save(any());
+    }
 }

--- a/application/src/test/java/team/themoment/officialgsm/domain/auth/usecase/TokenReissueUseCaseTest.java
+++ b/application/src/test/java/team/themoment/officialgsm/domain/auth/usecase/TokenReissueUseCaseTest.java
@@ -1,11 +1,11 @@
 package team.themoment.officialgsm.domain.auth.usecase;
 
-import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import team.themoment.officialgsm.common.exception.CustomException;
 import team.themoment.officialgsm.domain.auth.dto.ReissueTokenDto;
 import team.themoment.officialgsm.domain.auth.spi.TokenProvider;
 import team.themoment.officialgsm.domain.token.RefreshToken;
@@ -17,8 +17,11 @@ import team.themoment.officialgsm.repository.user.UserRepository;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.never;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -63,5 +66,15 @@ class TokenReissueUseCaseTest {
 
         assertThat(reissueTokenDto.getAccessToken()).isEqualTo("1");
         assertThat(reissueTokenDto.getRefreshToken()).isEqualTo("1");
+    }
+
+    @Test
+    void execute_refreshTokenIsNull() {
+        // given &  when
+        assertThrows(CustomException.class, () -> tokenReissueUseCase.execute(null));
+
+        // then
+        verify(userRepository, never()).findByOauthId(any());
+        verify(refreshTokenRepository, never()).save(any());
     }
 }

--- a/application/src/test/java/team/themoment/officialgsm/domain/auth/usecase/TokenReissueUseCaseTest.java
+++ b/application/src/test/java/team/themoment/officialgsm/domain/auth/usecase/TokenReissueUseCaseTest.java
@@ -98,4 +98,27 @@ class TokenReissueUseCaseTest {
 
         verify(refreshTokenRepository, never()).save(any());
     }
+
+    @Test
+    void execute_refreshTokenIsNotValid() {
+        // given
+        String refreshTokenValue = "0";
+        String oauthId = "0";
+        String refreshSecret = "0";
+
+        User user = new User(oauthId, "신희성", "s23012@gsm.hs.kr", Role.UNAPPROVED, null, null, null);
+        RefreshToken refreshToken = new RefreshToken(oauthId, refreshTokenValue + 1, 0L);
+
+        given(tokenProvider.getRefreshSecert()).willReturn(refreshSecret);
+        given(tokenProvider.getRefreshTokenOauthId(refreshTokenValue, refreshSecret)).willReturn(oauthId);
+
+        given(userRepository.findByOauthId(oauthId)).willReturn(Optional.of(user));
+        given(refreshTokenRepository.findByOauthId(oauthId)).willReturn(Optional.of(refreshToken));
+
+        // when
+        assertThrows(CustomException.class, () -> tokenReissueUseCase.execute(refreshTokenValue));
+
+        // then
+        verify(refreshTokenRepository, never()).save(any());
+    }
 }

--- a/presentation/src/test/java/team/themoment/officialgsm/admin/controller/approve/ApproveControllerTest.java
+++ b/presentation/src/test/java/team/themoment/officialgsm/admin/controller/approve/ApproveControllerTest.java
@@ -15,6 +15,7 @@ import team.themoment.officialgsm.admin.controller.approve.mapper.ApproveDataMap
 import team.themoment.officialgsm.admin.controller.auth.manager.UserManager;
 import team.themoment.officialgsm.domain.approve.dto.UnapprovedListDto;
 import team.themoment.officialgsm.domain.approve.usecase.ApprovedUseCase;
+import team.themoment.officialgsm.domain.approve.usecase.RefuseApprovedUseCase;
 import team.themoment.officialgsm.domain.approve.usecase.UnapprovedListUseCase;
 import team.themoment.officialgsm.domain.user.Role;
 
@@ -26,8 +27,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -42,6 +42,9 @@ class ApproveControllerTest {
 
     @Mock
     ApprovedUseCase approvedUseCase;
+
+    @Mock
+    RefuseApprovedUseCase refuseApprovedUseCase;
 
     @Mock
     UserManager userManager;
@@ -93,5 +96,19 @@ class ApproveControllerTest {
         resultActions.andExpect(status().isCreated());
 
         verify(approvedUseCase, times(1)).execute(eq(oauthId), any());
+    }
+
+    @Test
+    void refuseApproved() throws Exception {
+        // given
+        String oauthId = "0";
+
+        // when
+        ResultActions resultActions = mockMvc.perform(delete("/api/auth/approved/" + oauthId));
+
+        // then
+        resultActions.andExpect(status().isNoContent());
+
+        verify(refuseApprovedUseCase, times(1)).execute(oauthId);
     }
 }

--- a/presentation/src/test/java/team/themoment/officialgsm/admin/controller/approve/ApproveControllerTest.java
+++ b/presentation/src/test/java/team/themoment/officialgsm/admin/controller/approve/ApproveControllerTest.java
@@ -12,17 +12,22 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import team.themoment.officialgsm.admin.controller.approve.dto.response.UnapprovedListResponse;
 import team.themoment.officialgsm.admin.controller.approve.mapper.ApproveDataMapper;
+import team.themoment.officialgsm.admin.controller.auth.manager.UserManager;
 import team.themoment.officialgsm.domain.approve.dto.UnapprovedListDto;
+import team.themoment.officialgsm.domain.approve.usecase.ApprovedUseCase;
 import team.themoment.officialgsm.domain.approve.usecase.UnapprovedListUseCase;
 import team.themoment.officialgsm.domain.user.Role;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -34,6 +39,12 @@ class ApproveControllerTest {
 
     @Mock
     UnapprovedListUseCase unapprovedListUseCase;
+
+    @Mock
+    ApprovedUseCase approvedUseCase;
+
+    @Mock
+    UserManager userManager;
 
     @Mock
     ApproveDataMapper approveMapper;
@@ -68,5 +79,19 @@ class ApproveControllerTest {
 
         verify(unapprovedListUseCase, times(1)).execute();
         verify(approveMapper, times(1)).toUnapprovedListResponse(List.of(unapprovedListDto));
+    }
+
+    @Test
+    void approved() throws Exception {
+        // given
+        String oauthId = "0";
+
+        // when
+        ResultActions resultActions = mockMvc.perform(patch("/api/auth/approved/" + oauthId));
+
+        // then
+        resultActions.andExpect(status().isCreated());
+
+        verify(approvedUseCase, times(1)).execute(eq(oauthId), any());
     }
 }

--- a/presentation/src/test/java/team/themoment/officialgsm/admin/controller/approve/ApproveControllerTest.java
+++ b/presentation/src/test/java/team/themoment/officialgsm/admin/controller/approve/ApproveControllerTest.java
@@ -1,0 +1,28 @@
+package team.themoment.officialgsm.admin.controller.approve;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import team.themoment.officialgsm.admin.controller.approve.mapper.ApproveDataMapper;
+
+@ExtendWith(MockitoExtension.class)
+class ApproveControllerTest {
+
+    @InjectMocks
+    ApproveController approveController;
+
+    @Mock
+    ApproveDataMapper approveMapper;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    public void init() {
+        mockMvc = MockMvcBuilders.standaloneSetup(approveController)
+                .build();
+    }
+}

--- a/presentation/src/test/java/team/themoment/officialgsm/admin/controller/approve/ApproveControllerTest.java
+++ b/presentation/src/test/java/team/themoment/officialgsm/admin/controller/approve/ApproveControllerTest.java
@@ -1,19 +1,39 @@
 package team.themoment.officialgsm.admin.controller.approve;
 
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import team.themoment.officialgsm.admin.controller.approve.dto.response.UnapprovedListResponse;
 import team.themoment.officialgsm.admin.controller.approve.mapper.ApproveDataMapper;
+import team.themoment.officialgsm.domain.approve.dto.UnapprovedListDto;
+import team.themoment.officialgsm.domain.approve.usecase.UnapprovedListUseCase;
+import team.themoment.officialgsm.domain.user.Role;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)
 class ApproveControllerTest {
 
     @InjectMocks
     ApproveController approveController;
+
+    @Mock
+    UnapprovedListUseCase unapprovedListUseCase;
 
     @Mock
     ApproveDataMapper approveMapper;
@@ -24,5 +44,29 @@ class ApproveControllerTest {
     public void init() {
         mockMvc = MockMvcBuilders.standaloneSetup(approveController)
                 .build();
+    }
+
+    @Test
+    void unapprovedListFind() throws Exception {
+        // given
+        UnapprovedListDto unapprovedListDto = new UnapprovedListDto("0", "신희성", Role.ADMIN, LocalDateTime.now());
+        UnapprovedListResponse unapprovedListResponse = new UnapprovedListResponse("0", "신희성", Role.ADMIN, "");
+
+        given(unapprovedListUseCase.execute()).willReturn(List.of(unapprovedListDto));
+        given(approveMapper.toUnapprovedListResponse(List.of(unapprovedListDto))).willReturn(List.of(unapprovedListResponse));
+
+        // when
+        ResultActions resultActions = mockMvc.perform(get("/api/auth/unapproved/list"));
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", Matchers.hasSize(1)))
+                .andExpect(jsonPath("$[0].userName").value(unapprovedListResponse.getUserName()))
+                .andExpect(jsonPath("$[0].role").value("ADMIN"))
+                .andExpect(jsonPath("$[0].requestedAt").value(unapprovedListResponse.getRequestedAt()));
+
+        verify(unapprovedListUseCase, times(1)).execute();
+        verify(approveMapper, times(1)).toUnapprovedListResponse(List.of(unapprovedListDto));
     }
 }


### PR DESCRIPTION
## 개요

- Approve 부분의 controller, usecase 단위 테스트코드를 작성하였습니다.
- `feature/authTestCode` 브랜치에서 브랜치를 생성하여 작업하였습니다.

**ApproveControllerTest**
- `unapprovedListFind`, `approved`, `refuseApproved` controller 테스트 코드를 작성하였습니다.

**UnapprovedListUseCaseTest**
- execute: 데이터베이스에서 미승인 유저를 불러오는 메서드를 잘 실행하는지 확인합니다.
- execute_userNotFound: 미승인 유저가 없다면 예외를 발생시키는지 확인합니다.

**RefuseApprovedUseCaseTest**
- execute: 승인을 거절할 유저를 찾은 후 삭제 메서드를 잘 실행하는지 확인합니다.
- execute_userNotFound: 승인을 거절할 유저를 찾지 못할 시 예외를 발생시키는지 확인합니다.
